### PR TITLE
feat: 공통 컴포넌트 버튼 구현

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,1 @@
-pnpm test
+pnpm lint-staged

--- a/src/App.css
+++ b/src/App.css
@@ -1,124 +1,194 @@
-@import "tailwindcss";
-@import "tw-animate-css";
-@import "shadcn/tailwind.css";
+@import 'tailwindcss';
+@import 'tw-animate-css';
+@import 'shadcn/tailwind.css';
 
 @custom-variant dark (&:is(.dark *));
 
 @theme inline {
-    --radius-sm: calc(var(--radius) - 4px);
-    --radius-md: calc(var(--radius) - 2px);
-    --radius-lg: var(--radius);
-    --radius-xl: calc(var(--radius) + 4px);
-    --radius-2xl: calc(var(--radius) + 8px);
-    --radius-3xl: calc(var(--radius) + 12px);
-    --radius-4xl: calc(var(--radius) + 16px);
-    --color-background: var(--background);
-    --color-foreground: var(--foreground);
-    --color-card: var(--card);
-    --color-card-foreground: var(--card-foreground);
-    --color-popover: var(--popover);
-    --color-popover-foreground: var(--popover-foreground);
-    --color-primary: var(--primary);
-    --color-primary-foreground: var(--primary-foreground);
-    --color-secondary: var(--secondary);
-    --color-secondary-foreground: var(--secondary-foreground);
-    --color-muted: var(--muted);
-    --color-muted-foreground: var(--muted-foreground);
-    --color-accent: var(--accent);
-    --color-accent-foreground: var(--accent-foreground);
-    --color-destructive: var(--destructive);
-    --color-border: var(--border);
-    --color-input: var(--input);
-    --color-ring: var(--ring);
-    --color-chart-1: var(--chart-1);
-    --color-chart-2: var(--chart-2);
-    --color-chart-3: var(--chart-3);
-    --color-chart-4: var(--chart-4);
-    --color-chart-5: var(--chart-5);
-    --color-sidebar: var(--sidebar);
-    --color-sidebar-foreground: var(--sidebar-foreground);
-    --color-sidebar-primary: var(--sidebar-primary);
-    --color-sidebar-primary-foreground: var(--sidebar-primary-foreground);
-    --color-sidebar-accent: var(--sidebar-accent);
-    --color-sidebar-accent-foreground: var(--sidebar-accent-foreground);
-    --color-sidebar-border: var(--sidebar-border);
-    --color-sidebar-ring: var(--sidebar-ring);
+  --radius-sm: calc(var(--radius) - 4px);
+  --radius-md: calc(var(--radius) - 2px);
+  --radius-lg: var(--radius);
+  --radius-xl: calc(var(--radius) + 4px);
+  --radius-2xl: calc(var(--radius) + 8px);
+  --radius-3xl: calc(var(--radius) + 12px);
+  --radius-4xl: calc(var(--radius) + 16px);
+  --color-background: var(--background);
+  --color-foreground: var(--foreground);
+  --color-card: var(--card);
+  --color-card-foreground: var(--card-foreground);
+  --color-popover: var(--popover);
+  --color-popover-foreground: var(--popover-foreground);
+  --color-primary: var(--primary);
+  --color-primary-foreground: var(--primary-foreground);
+  --color-secondary: var(--secondary);
+  --color-secondary-foreground: var(--secondary-foreground);
+  --color-muted: var(--muted);
+  --color-muted-foreground: var(--muted-foreground);
+  --color-accent: var(--accent);
+  --color-accent-foreground: var(--accent-foreground);
+  --color-destructive: var(--destructive);
+  --color-border: var(--border);
+  --color-input: var(--input);
+  --color-ring: var(--ring);
+  --color-chart-1: var(--chart-1);
+  --color-chart-2: var(--chart-2);
+  --color-chart-3: var(--chart-3);
+  --color-chart-4: var(--chart-4);
+  --color-chart-5: var(--chart-5);
+  --color-sidebar: var(--sidebar);
+  --color-sidebar-foreground: var(--sidebar-foreground);
+  --color-sidebar-primary: var(--sidebar-primary);
+  --color-sidebar-primary-foreground: var(--sidebar-primary-foreground);
+  --color-sidebar-accent: var(--sidebar-accent);
+  --color-sidebar-accent-foreground: var(--sidebar-accent-foreground);
+  --color-sidebar-border: var(--sidebar-border);
+  --color-sidebar-ring: var(--sidebar-ring);
+
+  /**
+    * Figma 디자인 컬러 토큰 리스트 추가
+    */
+  --color-grey-1: var(--grey-1);
+  --color-grey-2: var(--grey-2);
+  --color-grey-3: var(--grey-3);
+  --color-grey-4: var(--grey-4);
+  --color-grey-5: var(--grey-5);
+  --color-grey-6: var(--grey-6);
+  --color-grey-7: var(--grey-7);
+  --color-grey-8: var(--grey-8);
+  --color-grey-9: var(--grey-9);
+  --color-grey-10: var(--grey-10);
+
+  --color-main-1: var(--main-1);
+  --color-main-2: var(--main-2);
+  --color-main-3: var(--main-3);
+  --color-main-4: var(--main-4);
+  --color-main-5: var(--main-5);
+  --color-main-6: var(--main-6);
+  --color-main-7: var(--main-7);
+  --color-btn-fill-default: var(--btn-fill-default);
+  --color-btn-fill-hover: var(--btn-fill-hover);
+  --color-btn-fill-active: var(--btn-fill-active);
+  --color-btn-outline-enabled-bg: var(--btn-outline-enabled-bg);
+
+  --color-other-green: var(--other-green);
+  --color-other-light-green: var(--other-light-green);
+  --color-other-red: var(--other-red);
+  --color-other-pale-pink: var(--other-pale-pink);
+  --color-other-yellow: var(--other-yellow);
+  --color-other-pale-yellow: var(--other-pale-yellow);
 }
 
 :root {
-    --radius: 0.625rem;
-    --background: oklch(1 0 0);
-    --foreground: oklch(0.129 0.042 264.695);
-    --card: oklch(1 0 0);
-    --card-foreground: oklch(0.129 0.042 264.695);
-    --popover: oklch(1 0 0);
-    --popover-foreground: oklch(0.129 0.042 264.695);
-    --primary: oklch(0.208 0.042 265.755);
-    --primary-foreground: oklch(0.984 0.003 247.858);
-    --secondary: oklch(0.968 0.007 247.896);
-    --secondary-foreground: oklch(0.208 0.042 265.755);
-    --muted: oklch(0.968 0.007 247.896);
-    --muted-foreground: oklch(0.554 0.046 257.417);
-    --accent: oklch(0.968 0.007 247.896);
-    --accent-foreground: oklch(0.208 0.042 265.755);
-    --destructive: oklch(0.577 0.245 27.325);
-    --border: oklch(0.929 0.013 255.508);
-    --input: oklch(0.929 0.013 255.508);
-    --ring: oklch(0.704 0.04 256.788);
-    --chart-1: oklch(0.646 0.222 41.116);
-    --chart-2: oklch(0.6 0.118 184.704);
-    --chart-3: oklch(0.398 0.07 227.392);
-    --chart-4: oklch(0.828 0.189 84.429);
-    --chart-5: oklch(0.769 0.188 70.08);
-    --sidebar: oklch(0.984 0.003 247.858);
-    --sidebar-foreground: oklch(0.129 0.042 264.695);
-    --sidebar-primary: oklch(0.208 0.042 265.755);
-    --sidebar-primary-foreground: oklch(0.984 0.003 247.858);
-    --sidebar-accent: oklch(0.968 0.007 247.896);
-    --sidebar-accent-foreground: oklch(0.208 0.042 265.755);
-    --sidebar-border: oklch(0.929 0.013 255.508);
-    --sidebar-ring: oklch(0.704 0.04 256.788);
+  --radius: 0.625rem;
+  --background: oklch(1 0 0);
+  --foreground: oklch(0.129 0.042 264.695);
+  --card: oklch(1 0 0);
+  --card-foreground: oklch(0.129 0.042 264.695);
+  --popover: oklch(1 0 0);
+  --popover-foreground: oklch(0.129 0.042 264.695);
+  --primary: oklch(0.208 0.042 265.755);
+  --primary-foreground: oklch(0.984 0.003 247.858);
+  --secondary: oklch(0.968 0.007 247.896);
+  --secondary-foreground: oklch(0.208 0.042 265.755);
+  --muted: oklch(0.968 0.007 247.896);
+  --muted-foreground: oklch(0.554 0.046 257.417);
+  --accent: oklch(0.968 0.007 247.896);
+  --accent-foreground: oklch(0.208 0.042 265.755);
+  --destructive: oklch(0.577 0.245 27.325);
+  --border: oklch(0.929 0.013 255.508);
+  --input: oklch(0.929 0.013 255.508);
+  --ring: oklch(0.704 0.04 256.788);
+  --chart-1: oklch(0.646 0.222 41.116);
+  --chart-2: oklch(0.6 0.118 184.704);
+  --chart-3: oklch(0.398 0.07 227.392);
+  --chart-4: oklch(0.828 0.189 84.429);
+  --chart-5: oklch(0.769 0.188 70.08);
+  --sidebar: oklch(0.984 0.003 247.858);
+  --sidebar-foreground: oklch(0.129 0.042 264.695);
+  --sidebar-primary: oklch(0.208 0.042 265.755);
+  --sidebar-primary-foreground: oklch(0.984 0.003 247.858);
+  --sidebar-accent: oklch(0.968 0.007 247.896);
+  --sidebar-accent-foreground: oklch(0.208 0.042 265.755);
+  --sidebar-border: oklch(0.929 0.013 255.508);
+  --sidebar-ring: oklch(0.704 0.04 256.788);
+
+  /**
+    * Figma 디자인 컬러 토큰 리스트 추가
+    */
+
+  /** Grey */
+  --grey-1: #ffffff;
+  --grey-2: #f5f5f5;
+  --grey-3: #dddddd;
+  --grey-4: #a6a6a6;
+  --grey-5: #666666;
+  --grey-6: #222222;
+  --grey-7: #ececec;
+  --grey-8: #4d4d4d;
+  --grey-9: #bdbdbd;
+  --grey-10: #cecece;
+
+  /** Main */
+  --main-1: #f2effd;
+  --main-2: #ede6ff;
+  --main-3: #d7cbf7;
+  --main-4: #b69cf1;
+  --main-5: #986be9;
+  --main-6: #7c35d9;
+  --main-7: #522193;
+  --btn-fill-default: #6201e0;
+  --btn-fill-hover: #4e01b3;
+  --btn-fill-active: #3b0186;
+  --btn-outline-enabled-bg: #efe6fc;
+
+  /** Other */
+  --other-green: #5eb669;
+  --other-light-green: #e7f429;
+  --other-red: #cc0a0a;
+  --other-pale-pink: #f9e2e2;
+  --other-yellow: #f6a818;
+  --other-pale-yellow: #fdeece;
 }
 
 .dark {
-    --background: oklch(0.129 0.042 264.695);
-    --foreground: oklch(0.984 0.003 247.858);
-    --card: oklch(0.208 0.042 265.755);
-    --card-foreground: oklch(0.984 0.003 247.858);
-    --popover: oklch(0.208 0.042 265.755);
-    --popover-foreground: oklch(0.984 0.003 247.858);
-    --primary: oklch(0.929 0.013 255.508);
-    --primary-foreground: oklch(0.208 0.042 265.755);
-    --secondary: oklch(0.279 0.041 260.031);
-    --secondary-foreground: oklch(0.984 0.003 247.858);
-    --muted: oklch(0.279 0.041 260.031);
-    --muted-foreground: oklch(0.704 0.04 256.788);
-    --accent: oklch(0.279 0.041 260.031);
-    --accent-foreground: oklch(0.984 0.003 247.858);
-    --destructive: oklch(0.704 0.191 22.216);
-    --border: oklch(1 0 0 / 10%);
-    --input: oklch(1 0 0 / 15%);
-    --ring: oklch(0.551 0.027 264.364);
-    --chart-1: oklch(0.488 0.243 264.376);
-    --chart-2: oklch(0.696 0.17 162.48);
-    --chart-3: oklch(0.769 0.188 70.08);
-    --chart-4: oklch(0.627 0.265 303.9);
-    --chart-5: oklch(0.645 0.246 16.439);
-    --sidebar: oklch(0.208 0.042 265.755);
-    --sidebar-foreground: oklch(0.984 0.003 247.858);
-    --sidebar-primary: oklch(0.488 0.243 264.376);
-    --sidebar-primary-foreground: oklch(0.984 0.003 247.858);
-    --sidebar-accent: oklch(0.279 0.041 260.031);
-    --sidebar-accent-foreground: oklch(0.984 0.003 247.858);
-    --sidebar-border: oklch(1 0 0 / 10%);
-    --sidebar-ring: oklch(0.551 0.027 264.364);
+  --background: oklch(0.129 0.042 264.695);
+  --foreground: oklch(22.74% 0.01474 248.521);
+  --card: oklch(0.208 0.042 265.755);
+  --card-foreground: oklch(0.984 0.003 247.858);
+  --popover: oklch(0.208 0.042 265.755);
+  --popover-foreground: oklch(0.984 0.003 247.858);
+  --primary: oklch(0.929 0.013 255.508);
+  --primary-foreground: oklch(0.208 0.042 265.755);
+  --secondary: oklch(0.279 0.041 260.031);
+  --secondary-foreground: oklch(0.984 0.003 247.858);
+  --muted: oklch(0.279 0.041 260.031);
+  --muted-foreground: oklch(0.704 0.04 256.788);
+  --accent: oklch(0.279 0.041 260.031);
+  --accent-foreground: oklch(0.984 0.003 247.858);
+  --destructive: oklch(0.704 0.191 22.216);
+  --border: oklch(1 0 0 / 10%);
+  --input: oklch(1 0 0 / 15%);
+  --ring: oklch(0.551 0.027 264.364);
+  --chart-1: oklch(0.488 0.243 264.376);
+  --chart-2: oklch(0.696 0.17 162.48);
+  --chart-3: oklch(0.769 0.188 70.08);
+  --chart-4: oklch(0.627 0.265 303.9);
+  --chart-5: oklch(0.645 0.246 16.439);
+  --sidebar: oklch(0.208 0.042 265.755);
+  --sidebar-foreground: oklch(0.984 0.003 247.858);
+  --sidebar-primary: oklch(0.488 0.243 264.376);
+  --sidebar-primary-foreground: oklch(0.984 0.003 247.858);
+  --sidebar-accent: oklch(0.279 0.041 260.031);
+  --sidebar-accent-foreground: oklch(0.984 0.003 247.858);
+  --sidebar-border: oklch(1 0 0 / 10%);
+  --sidebar-ring: oklch(0.551 0.027 264.364);
 }
 
 @layer base {
   * {
     @apply border-border outline-ring/50;
-    }
+  }
   body {
     @apply bg-background text-foreground;
-    }
+  }
 }

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -1,0 +1,110 @@
+import * as React from 'react'
+import { cva, type VariantProps } from 'class-variance-authority'
+import { Slot } from 'radix-ui'
+
+import { cn } from '@/lib/utils'
+
+const buttonVariants = cva(
+  [
+    'inline-flex shrink-0 items-center justify-center whitespace-nowrap',
+    'font-medium transition-colors',
+    'outline-none',
+    'disabled:pointer-events-none',
+    '[&_svg]:pointer-events-none [&_svg]:shrink-0',
+  ].join(' '),
+  {
+    variants: {
+      variant: {
+        fill: [
+          'bg-btn-fill-default text-grey-1',
+          'hover:bg-btn-fill-hover',
+          'active:bg-btn-fill-active',
+          'disabled:bg-grey-2 disabled:text-grey-4',
+        ].join(' '),
+
+        ghost: [
+          'bg-[var(--grey-3)] text-grey-6',
+          'hover:bg-grey-4',
+          'active:bg-grey-5 active:text-grey-1',
+          'disabled:bg-grey-2 disabled:text-grey-4',
+        ].join(' '),
+
+        outline: [
+          'border border-btn-fill-default bg-btn-outline-enabled-bg text-btn-fill-default',
+          'hover:bg-main-4',
+          'active:bg-btn-outline-enabled-bg',
+          'disabled:border-grey-10 disabled:bg-grey-7 disabled:text-grey-8',
+        ].join(' '),
+
+        sidebarTab: [
+          'relative justify-start font-semibold',
+          'bg-grey-1 text-grey-4',
+          'hover:bg-btn-outline-enabled-bg hover:text-btn-fill-default',
+          'disabled:bg-grey-7 disabled:text-grey-9',
+        ].join(' '),
+      },
+
+      size: {
+        sm: 'h-12 w-[112px] rounded-lg px-5 py-6 text-[16px]',
+        md: 'h-12 w-[155px] rounded-lg px-5 py-6 text-[16px]',
+        sidebarTab: 'h-8 w-[152px] rounded-lg p-5 text-[18px]',
+        full: 'h-14 w-full rounded-lg p-8 text-[16px]',
+      },
+      active: {
+        true: '',
+        false: '',
+      },
+    },
+
+    compoundVariants: [
+      {
+        variant: 'sidebarTab',
+        active: true,
+        className: [
+          'text-main-6',
+          'before:absolute',
+          'before:left-0',
+          'before:top-1/2',
+          'before:h-6',
+          'before:w-[3px]',
+          'before:-translate-y-1/2',
+          'before:rounded-full',
+          'before:bg-main-6',
+        ].join(' '),
+      },
+    ],
+
+    defaultVariants: {
+      variant: 'fill',
+      size: 'md',
+      active: false,
+    },
+  }
+)
+
+export default function Button({
+  className,
+  variant,
+  size,
+  active,
+  asChild = false,
+  disabled,
+  ...props
+}: React.ComponentProps<'button'> &
+  VariantProps<typeof buttonVariants> & {
+    asChild?: boolean
+  }) {
+  const Comp = asChild ? Slot.Root : 'button'
+
+  return (
+    <Comp
+      data-slot="button"
+      data-variant={variant}
+      data-size={size}
+      data-active={active}
+      disabled={disabled}
+      className={cn(buttonVariants({ variant, size, active }), className)}
+      {...props}
+    />
+  )
+}

--- a/src/test/TestButton.tsx
+++ b/src/test/TestButton.tsx
@@ -1,0 +1,38 @@
+import Button from '@/components/ui/button'
+
+export default function TestButton() {
+  return (
+    <>
+      <Button variant="fill" size="sm">
+        fill
+      </Button>
+      <Button variant="ghost" size="md">
+        ghost
+      </Button>
+      <Button variant="ghost" size="sm">
+        ghost
+      </Button>
+      <Button variant="outline" size="md">
+        outline
+      </Button>
+      <Button variant="outline" size="md" disabled>
+        outline
+      </Button>
+      <Button variant="fill" size="full">
+        가입하기
+      </Button>
+      <Button variant="fill" size="full" disabled>
+        가입하기
+      </Button>
+      <Button variant="sidebarTab" size="sidebarTab">
+        사이드바탭
+      </Button>
+      <Button variant="sidebarTab" size="sidebarTab" active>
+        사이드바탭
+      </Button>
+      <Button variant="sidebarTab" size="sidebarTab" disabled>
+        사이드바탭
+      </Button>
+    </>
+  )
+}


### PR DESCRIPTION
## 📌 작업 내용

디자인 토큰 적용
- App.css에 디자인 토큰 적용
- 샤드씨엔 설치 시 생성된 디자인 토큰은 불필요시 삭제 예정
- .husky/pre-commit 파일 수정 (pnpm test -> pnpm exec lint-staged)

공통 컴포넌트 버튼 구현
- 공통 컴포넌트 버튼 구현
- 버튼의 variant로 fill, outline, sidebarTab 추가
- 버튼의 size로 sm, md, sidebarTab, full 추가
- sidebarTab variant에 active 상태 추가
- src/test폴더에 TestButton 컴포넌트 추가

## 🔗 관련 이슈

- closes #9

## 📸 스크린샷 (선택)

<img width="366" height="120" alt="스크린샷 2026-03-09 오후 3 29 04" src="https://github.com/user-attachments/assets/8938c8b5-add1-4201-b929-5e60a34c1e78" />

## ✅ 체크리스트

- [ ] 코드 컨벤션 확인
- [ ] lint 에러 없음
- [ ] 빌드 정상 확인
