### PR TITLE
feat: ExamEmptyState 페이지 구현

### DIFF
--- a/src/assets/images/not-exam-icon.svg
+++ b/src/assets/images/not-exam-icon.svg
@@ -1,0 +1,9 @@
+<svg width="73" height="68" viewBox="0 0 73 68" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect x="1" y="1" width="54.7606" height="66" rx="6" fill="white" stroke="#BDBDBD" stroke-width="2"/>
+<path d="M40.5491 23H11.1406" stroke="#BDBDBD" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M40.5491 31H11.1406" stroke="#BDBDBD" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M19.2533 15H15.197H11.1406" stroke="#BDBDBD" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M51.1813 52.7486C58.5968 52.7486 64.6082 46.7371 64.6082 39.3217C64.6082 31.9062 58.5968 25.8948 51.1813 25.8948C43.7658 25.8948 37.7544 31.9062 37.7544 39.3217C37.7544 46.7371 43.7658 52.7486 51.1813 52.7486Z" fill="white" stroke="#BDBDBD" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M41.7192 39.6947C41.7192 35.2485 44.6695 31.4915 48.7192 30.2744" stroke="#BDBDBD" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M68.9717 57.1123L60.9155 49.0562" stroke="#BDBDBD" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/components/common/EmptyState.tsx
+++ b/src/components/common/EmptyState.tsx
@@ -1,0 +1,36 @@
+import { cn } from '@/lib/utils'
+import type { ReactNode } from 'react'
+
+type EmptyStateProps = {
+  icon?: ReactNode
+  title: string
+  description?: string
+  action?: ReactNode
+  className?: string
+}
+
+export default function EmptyState({
+  icon,
+  title,
+  description,
+  action,
+  className,
+}: EmptyStateProps) {
+  return (
+    <div
+      className={cn(
+        'flex flex-col items-center justify-center gap-5 text-center',
+        className
+      )}
+    >
+      {icon && <div>{icon}</div>}
+
+      <div className="flex flex-col gap-1 text-base font-medium text-gray-400">
+        <p>{title}</p>
+        {description && <p>{description}</p>}
+      </div>
+
+      {action && <div>{action}</div>}
+    </div>
+  )
+}

--- a/src/components/exam/ExamEmptyState.tsx
+++ b/src/components/exam/ExamEmptyState.tsx
@@ -1,0 +1,13 @@
+import NotExamIcon from '@/assets/images/not-exam-icon.svg?react'
+import EmptyState from '../common/EmptyState'
+
+/**
+ * ExamEmptyState
+ * 응시 할 시험이 없을 경우 사용되는 컴포넌트
+ * 부모 컨테이너에서 높이 조절
+ */
+export default function ExamEmptyState() {
+  return (
+    <EmptyState icon={<NotExamIcon />} title="아직 응시 할 시험이 없어요." />
+  )
+}

--- a/src/pages/NotFoundPage.tsx
+++ b/src/pages/NotFoundPage.tsx
@@ -1,4 +1,5 @@
 import NotFoundImage from '@/assets/images/not-found.svg?react'
+import EmptyState from '@/components/common/EmptyState'
 import Button from '@/components/ui/button'
 import { ROUTES_PATHS } from '@/constants/routesPaths'
 import { Link } from 'react-router-dom'
@@ -8,17 +9,18 @@ import { Link } from 'react-router-dom'
  */
 export default function NotFoundPage() {
   return (
-    <div className="flex min-h-screen flex-col items-center justify-center gap-5 text-center">
-      <NotFoundImage />
-      <div className="text-base font-medium text-gray-400">
-        <p>페이지를 불러올 수 없어요.</p>
-        <p>잠시 뒤 다시 시도해보세요!</p>
-      </div>
-      <Link to={ROUTES_PATHS.HOME_PAGE}>
-        <Button variant="notFound" size="sm" className="h-2 p-5">
-          홈으로
-        </Button>
-      </Link>
-    </div>
+    <EmptyState
+      icon={<NotFoundImage />}
+      title="페이지를 불러올 수 없어요."
+      description="잠시 뒤 다시 시도해보세요!"
+      action={
+        <Link to={ROUTES_PATHS.HOME_PAGE}>
+          <Button variant="notFound" size="sm" className="h-2 p-5">
+            홈으로
+          </Button>
+        </Link>
+      }
+      className="min-h-screen"
+    />
   )
 }

--- a/src/pages/TestPage.tsx
+++ b/src/pages/TestPage.tsx
@@ -1,5 +1,6 @@
 import Dropdown from '@/components/common/Dropdown'
 import Toast from '@/components/common/Toast'
+import ExamEmptyState from '@/components/exam/ExamEmptyState'
 import TestButton from '@/test/TestButton'
 import TestInput from '@/test/TestInput'
 
@@ -11,6 +12,9 @@ function TestPage() {
       <Toast />
       <TestButton />
       <TestInput />
+      <div className="flex min-h-90 items-center justify-center">
+        <ExamEmptyState />
+      </div>
     </div>
   )
 }


### PR DESCRIPTION
## 📌 작업 내용

- 쪽지시험이 없을 경우 사용하는 컴포넌트인 ExamEmptyState 구현
- EmptyState 컴포넌트를 생성 및 공통으로 사용하도록 수정 (NotFoundPage, ExamEmptyState)
- 컴포넌트에 사용되는 아이콘 생성
- 테스트 페이지에 컴포넌트 추가

## 🔗 관련 이슈

- closes #33 

## 📸 스크린샷 (선택)
<img width="421" height="324" alt="스크린샷 2026-03-11 오후 6 11 19" src="https://github.com/user-attachments/assets/5f1ed0c7-c9a0-4d09-8c96-88d5a47818ca" />

## ✅ 체크리스트

- [ ] 코드 컨벤션 확인
- [ ] lint 에러 없음
- [ ] 빌드 정상 확인
