### PR TITLE
feat: 회원탈퇴 계정 복구 모달 UI 구현

### DIFF
--- a/src/assets/icons/RecoveryIcon.svg
+++ b/src/assets/icons/RecoveryIcon.svg
@@ -1,7 +1,14 @@
-<svg width="40" height="40" viewBox="0 0 40 40" fill="none" xmlns="http://www.w3.org/2000/svg">
-  <circle cx="20" cy="20" r="20" fill="#EFE6FC"/>
-  <circle cx="20" cy="20" r="13" stroke="#4E01B3" stroke-width="3"/>
-  <circle cx="16.5" cy="17.5" r="1.5" fill="#4E01B3"/>
-  <circle cx="23.5" cy="17.5" r="1.5" fill="#4E01B3"/>
-  <path d="M15 24H25" stroke="#4E01B3" stroke-width="3" stroke-linecap="round"/>
+<svg width="28" height="28" viewBox="0 0 28 28" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect width="28" height="28" rx="14" fill="#D0B3F6"/>
+<g clip-path="url(#clip0_91_4001)">
+<path d="M14.0003 22.3346C18.6027 22.3346 22.3337 18.6037 22.3337 14.0013C22.3337 9.39893 18.6027 5.66797 14.0003 5.66797C9.39795 5.66797 5.66699 9.39893 5.66699 14.0013C5.66699 18.6037 9.39795 22.3346 14.0003 22.3346Z" stroke="#6201E0" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M10.667 16.5H17.3337" stroke="#6201E0" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M11.5 11.5H11.5083" stroke="#6201E0" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M16.5 11.5H16.5083" stroke="#6201E0" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</g>
+<defs>
+<clipPath id="clip0_91_4001">
+<rect width="20" height="20" fill="white" transform="translate(4 4)"/>
+</clipPath>
+</defs>
 </svg>

--- a/src/assets/icons/RecoveryVerifyIcon.svg
+++ b/src/assets/icons/RecoveryVerifyIcon.svg
@@ -1,0 +1,12 @@
+<svg width="28" height="28" viewBox="0 0 28 28" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect width="28" height="28" rx="14" fill="#D0B3F6"/>
+<g clip-path="url(#clip0_91_4214)">
+<path d="M21.334 8.66797V12.668H17.334" stroke="#6201E0" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M19.6593 15.9987C19.2259 17.2253 18.4056 18.2779 17.322 18.9977C16.2384 19.7176 14.9502 20.0657 13.6515 19.9898C12.3529 19.9138 11.114 19.4178 10.1218 18.5765C9.12951 17.7352 8.43755 16.5942 8.15018 15.3254C7.86281 14.0566 7.99559 12.7288 8.52851 11.5421C9.06143 10.3553 9.96563 9.37395 11.1048 8.7458C12.244 8.11765 13.5566 7.87677 14.8446 8.05947C16.1326 8.24216 17.3263 8.83853 18.2459 9.75871L21.3326 12.6654" stroke="#6201E0" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+</g>
+<defs>
+<clipPath id="clip0_91_4214">
+<rect width="16" height="16" fill="white" transform="translate(6 6)"/>
+</clipPath>
+</defs>
+</svg>

--- a/src/components/common/CodeVerification.tsx
+++ b/src/components/common/CodeVerification.tsx
@@ -1,5 +1,3 @@
-import { type ChangeEvent } from 'react'
-
 import Button from '@/components/ui/button'
 import Input from '@/components/ui/input'
 
@@ -8,13 +6,13 @@ type CodeVerificationProps = {
   required?: boolean
   targetInputId: string
   targetValue: string
-  onTargetChange: (e: ChangeEvent<HTMLInputElement>) => void
+  onTargetChange: (value: string) => void
   targetPlaceholder: string
   targetInputType?: 'text' | 'email'
   targetInputMode?: 'text' | 'numeric'
   verificationCodeInputId: string
   verificationCode: string
-  onVerificationCodeChange: (e: ChangeEvent<HTMLInputElement>) => void
+  onVerificationCodeChange: (value: string) => void
   verificationCodePlaceholder: string
   onSendCode: () => void
   onVerifyCode: () => void
@@ -22,16 +20,9 @@ type CodeVerificationProps = {
   isCodeVerified: boolean
   errorMessage: string
   successMessage?: string
-  timeLeft: number
+  formattedTime: string
   sendButtonText?: string
   verifyButtonText?: string
-}
-
-const formatTime = (seconds: number) => {
-  const minute = Math.floor(seconds / 60)
-  const second = seconds % 60
-
-  return `${String(minute).padStart(2, '0')}:${String(second).padStart(2, '0')}`
 }
 
 const verificationBtnClassName =
@@ -56,15 +47,14 @@ const CodeVerification = ({
   isCodeVerified,
   errorMessage,
   successMessage = '인증코드가 일치합니다.',
-  timeLeft,
+  formattedTime,
   sendButtonText = '인증코드전송',
   verifyButtonText = '인증코드확인',
 }: CodeVerificationProps) => {
   const hasError = Boolean(errorMessage)
-  const isTimerExpired = isCodeSent && timeLeft <= 0
 
   const codeBorderClass = (() => {
-    if (hasError || isTimerExpired) return 'border-other-red'
+    if (hasError) return 'border-other-red'
     if (isCodeVerified) return 'border-other-green'
     return 'border-grey-9 focus:border-btn-fill-default'
   })()
@@ -86,7 +76,7 @@ const CodeVerification = ({
             type={targetInputType}
             inputMode={targetInputMode}
             value={targetValue}
-            onChange={onTargetChange}
+            onChange={(e) => onTargetChange(e.target.value)}
             placeholder={targetPlaceholder}
             className="flex-1"
           />
@@ -110,14 +100,14 @@ const CodeVerification = ({
                 type="text"
                 inputMode="numeric"
                 value={verificationCode}
-                onChange={onVerificationCodeChange}
+                onChange={(e) => onVerificationCodeChange(e.target.value)}
                 placeholder={verificationCodePlaceholder}
-                className={`bg-grey-1 placeholder:text-grey-9 flex h-[48px] w-full rounded-[4px] border px-[16px] py-[10px] font-['Pretendard'] text-[16px] leading-[140%] tracking-[-0.03em] transition-all focus:outline-none ${isCodeSent ? 'pr-[64px]' : ''} ${codeBorderClass}`}
+                className={`bg-grey-1 placeholder:text-grey-9 flex h-[48px] w-full rounded-[4px] border px-[16px] py-[10px] font-['Pretendard'] text-[16px] leading-[140%] tracking-[-0.03em] transition-all focus:outline-none ${isCodeSent && !isCodeVerified ? 'pr-[64px]' : ''} ${codeBorderClass}`}
               />
 
-              {isCodeSent && (
+              {isCodeSent && !isCodeVerified && (
                 <span className="text-other-red absolute top-1/2 right-[16px] -translate-y-1/2 text-[14px] leading-[17px] tracking-[-0.03em]">
-                  {formatTime(timeLeft)}
+                  {formattedTime}
                 </span>
               )}
             </div>

--- a/src/components/common/CodeVerification.tsx
+++ b/src/components/common/CodeVerification.tsx
@@ -1,0 +1,153 @@
+import { type ChangeEvent } from 'react'
+
+import Button from '@/components/ui/button'
+import Input from '@/components/ui/input'
+
+type CodeVerificationProps = {
+  label: string
+  required?: boolean
+  targetInputId: string
+  targetValue: string
+  onTargetChange: (e: ChangeEvent<HTMLInputElement>) => void
+  targetPlaceholder: string
+  targetInputType?: 'text' | 'email'
+  targetInputMode?: 'text' | 'numeric'
+  verificationCodeInputId: string
+  verificationCode: string
+  onVerificationCodeChange: (e: ChangeEvent<HTMLInputElement>) => void
+  verificationCodePlaceholder: string
+  onSendCode: () => void
+  onVerifyCode: () => void
+  isCodeSent: boolean
+  isCodeVerified: boolean
+  errorMessage: string
+  successMessage?: string
+  timeLeft: number
+  sendButtonText?: string
+  verifyButtonText?: string
+}
+
+const formatTime = (seconds: number) => {
+  const minute = Math.floor(seconds / 60)
+  const second = seconds % 60
+
+  return `${String(minute).padStart(2, '0')}:${String(second).padStart(2, '0')}`
+}
+
+const verificationBtnClassName =
+  '!h-[48px] !w-[112px] !rounded-[4px] !border !border-[#BDBDBD] !px-[16px] !py-[20px] !text-[16px] !font-semibold whitespace-nowrap'
+
+const CodeVerification = ({
+  label,
+  required = false,
+  targetInputId,
+  targetValue,
+  onTargetChange,
+  targetPlaceholder,
+  targetInputType = 'text',
+  targetInputMode = 'text',
+  verificationCodeInputId,
+  verificationCode,
+  onVerificationCodeChange,
+  verificationCodePlaceholder,
+  onSendCode,
+  onVerifyCode,
+  isCodeSent,
+  isCodeVerified,
+  errorMessage,
+  successMessage = '인증코드가 일치합니다.',
+  timeLeft,
+  sendButtonText = '인증코드전송',
+  verifyButtonText = '인증코드확인',
+}: CodeVerificationProps) => {
+  const hasError = Boolean(errorMessage)
+  const isTimerExpired = isCodeSent && timeLeft <= 0
+
+  const codeBorderClass = (() => {
+    if (hasError || isTimerExpired) return 'border-other-red'
+    if (isCodeVerified) return 'border-other-green'
+    return 'border-grey-9 focus:border-btn-fill-default'
+  })()
+
+  return (
+    <div className="flex flex-col gap-[12px]">
+      <label
+        htmlFor={targetInputId}
+        className="text-ui-gray-primary text-[16px] leading-[140%] font-normal tracking-[-0.03em]"
+      >
+        {label}
+        {required && <span className="text-other-red">*</span>}
+      </label>
+
+      <div className="flex flex-col gap-[20px]">
+        <div className="flex gap-[8px]">
+          <Input
+            id={targetInputId}
+            type={targetInputType}
+            inputMode={targetInputMode}
+            value={targetValue}
+            onChange={onTargetChange}
+            placeholder={targetPlaceholder}
+            className="flex-1"
+          />
+
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            className={verificationBtnClassName}
+            onClick={onSendCode}
+          >
+            {sendButtonText}
+          </Button>
+        </div>
+
+        <div className="flex flex-col">
+          <div className="flex gap-[8px]">
+            <div className="relative flex-1">
+              <input
+                id={verificationCodeInputId}
+                type="text"
+                inputMode="numeric"
+                value={verificationCode}
+                onChange={onVerificationCodeChange}
+                placeholder={verificationCodePlaceholder}
+                className={`bg-grey-1 placeholder:text-grey-9 flex h-[48px] w-full rounded-[4px] border px-[16px] py-[10px] font-['Pretendard'] text-[16px] leading-[140%] tracking-[-0.03em] transition-all focus:outline-none ${isCodeSent ? 'pr-[64px]' : ''} ${codeBorderClass}`}
+              />
+
+              {isCodeSent && (
+                <span className="text-other-red absolute top-1/2 right-[16px] -translate-y-1/2 text-[14px] leading-[17px] tracking-[-0.03em]">
+                  {formatTime(timeLeft)}
+                </span>
+              )}
+            </div>
+
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              className={verificationBtnClassName}
+              onClick={onVerifyCode}
+            >
+              {verifyButtonText}
+            </Button>
+          </div>
+
+          {hasError && (
+            <p className="text-other-red mt-[12px] text-[14px] leading-[140%] font-normal tracking-[-0.03em]">
+              {errorMessage}
+            </p>
+          )}
+
+          {isCodeVerified && !hasError && (
+            <p className="text-other-green mt-[12px] text-[14px] leading-[140%] font-normal tracking-[-0.03em]">
+              {successMessage}
+            </p>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default CodeVerification

--- a/src/components/ui/modal/Modal.tsx
+++ b/src/components/ui/modal/Modal.tsx
@@ -3,19 +3,6 @@ import { createPortal } from 'react-dom'
 import { useModalScroll } from '@/hooks/useModalScroll'
 import { cn } from '@/lib/utils'
 
-/**
- * X버튼이 있는 모달 컴포넌트 (배경 클릭으로 닫히지 않음)
- * @param isOpen - 모달 열림 여부
- * @param onClose - 닫기 핸들러
- * @param children - 모달 내부 콘텐츠
- * @param width - 모달 너비 (Tailwind 클래스)
- * @param shadow - 그림자 여부 (기본값: true)
- * @example
- * <Modal isOpen={isOpen} onClose={handleClose} width="w-[396px]">
- *   <div>내용</div>
- * </Modal>
- */
-
 type ModalProps = {
   isOpen: boolean
   onClose: () => void
@@ -35,24 +22,23 @@ export default function Modal({
 
   if (!isOpen) return null
 
-  const modalRoot = document.getElementById('modal-root') ?? document.body
-
   return createPortal(
     <div
       role="dialog"
       aria-modal="true"
-      className="fixed inset-0 z-[1000] flex items-center justify-center bg-black/50"
+      className="bg-ui-gray-primary/60 fixed inset-0 z-[1000] grid place-items-center p-4"
     >
       <div
         className={cn(
-          'relative overflow-hidden rounded-[12px] bg-white',
+          'relative max-h-[calc(100dvh-32px)] w-full overflow-y-auto rounded-[12px] bg-white',
           shadow && 'shadow-[0_4px_16px_rgba(160,160,160,0.25)]',
-          width
+          width ?? 'max-w-[396px]'
         )}
         onClick={(e) => e.stopPropagation()}
       >
         <div className="flex justify-end px-[24px] pt-[20px]">
           <button
+            type="button"
             onClick={onClose}
             className="text-ui-gray-400 hover:text-ui-gray-600 cursor-pointer"
           >
@@ -69,9 +55,10 @@ export default function Modal({
             </svg>
           </button>
         </div>
+
         {children}
       </div>
     </div>,
-    modalRoot
+    document.body
   )
 }

--- a/src/features/auth/login/RecoverAccountModal.tsx
+++ b/src/features/auth/login/RecoverAccountModal.tsx
@@ -5,8 +5,9 @@ import RecoveryVerifyIconSvg from '@/assets/icons/RecoveryVerifyIcon.svg?react'
 import CheckToastIconSvg from '@/assets/icons/checkToast.svg?react'
 import Button from '@/components/ui/button'
 import Modal from '@/components/ui/modal/Modal'
+import Popup from '@/components/ui/modal/Popup'
 
-type RecoverStep = 'inactive' | 'verify' | 'complete'
+type RecoverStep = 'inactive' | 'verify'
 
 type RecoverAccountModalProps = {
   isOpen: boolean
@@ -30,6 +31,7 @@ const RecoverAccountModal = ({ isOpen, onClose }: RecoverAccountModalProps) => {
   const [isCodeVerified, setIsCodeVerified] = useState(false)
   const [codeErrorMessage, setCodeErrorMessage] = useState('')
   const [isSendMessageVisible, setIsSendMessageVisible] = useState(false)
+  const [isCompletePopupVisible, setIsCompletePopupVisible] = useState(false)
   const [timeLeft, setTimeLeft] = useState(INITIAL_TIMER)
 
   const hasCodeError = Boolean(codeErrorMessage)
@@ -43,6 +45,7 @@ const RecoverAccountModal = ({ isOpen, onClose }: RecoverAccountModalProps) => {
       setIsCodeVerified(false)
       setCodeErrorMessage('')
       setIsSendMessageVisible(false)
+      setIsCompletePopupVisible(false)
       setTimeLeft(INITIAL_TIMER)
     }
   }, [isOpen])
@@ -162,10 +165,11 @@ const RecoverAccountModal = ({ isOpen, onClose }: RecoverAccountModalProps) => {
     }
 
     setCodeErrorMessage('')
-    setStep('complete')
+    setIsCompletePopupVisible(true)
   }
 
-  const handleCompletePopupConfirmBtnClick = () => {
+  const handleCompletePopupClose = () => {
+    setIsCompletePopupVisible(false)
     onClose()
   }
 
@@ -181,6 +185,29 @@ const RecoverAccountModal = ({ isOpen, onClose }: RecoverAccountModalProps) => {
           전송 완료! 이메일을 확인해주세요.
         </span>
       </div>
+    )
+  }
+
+  const renderCompletePopup = () => {
+    return (
+      <Popup
+        isOpen={isOpen && isCompletePopupVisible}
+        onClose={handleCompletePopupClose}
+        width="w-[410px]"
+        isNested
+      >
+        <div className="flex flex-col items-center px-[32px] py-[40px] text-center">
+          <CheckToastIconSvg className="mb-[20px] h-[40px] w-[40px]" />
+
+          <h2 className="text-ui-gray-primary mb-[16px] text-[20px] leading-[140%] font-bold tracking-[-0.03em]">
+            계정 복구 완료!
+          </h2>
+
+          <p className="text-ui-gray-600 text-[14px] leading-[140%] font-normal tracking-[-0.03em]">
+            지금 바로 로그인해 보세요
+          </p>
+        </div>
+      </Popup>
     )
   }
 
@@ -314,38 +341,16 @@ const RecoverAccountModal = ({ isOpen, onClose }: RecoverAccountModalProps) => {
     )
   }
 
-  const renderCompleteContent = () => {
-    return (
-      <div className="flex flex-col items-center gap-[12px] px-[24px] pb-[24px] text-center">
-        <CheckToastIconSvg className="h-[24px] w-[24px]" />
-
-        <h2 className="text-ui-gray-primary text-[20px] leading-[140%] font-bold tracking-[-0.03em]">
-          계정 복구 완료!
-        </h2>
-
-        <p className="text-ui-gray-600 text-[14px] leading-[140%] font-normal tracking-[-0.03em]">
-          지금 바로 로그인해 보세요
-        </p>
-
-        <Button
-          variant="fill"
-          size="full"
-          onClick={handleCompletePopupConfirmBtnClick}
-        >
-          확인
-        </Button>
-      </div>
-    )
-  }
-
   return (
     <>
       {renderSendSuccessMessage()}
+      {renderCompletePopup()}
 
       <Modal isOpen={isOpen} onClose={onClose} width="w-[396px]">
-        {step === 'inactive' && renderInactiveContent()}
-        {step === 'verify' && renderVerifyContent()}
-        {step === 'complete' && renderCompleteContent()}
+        {step === 'inactive' &&
+          !isCompletePopupVisible &&
+          renderInactiveContent()}
+        {step === 'verify' && !isCompletePopupVisible && renderVerifyContent()}
       </Modal>
     </>
   )

--- a/src/features/auth/login/RecoverAccountModal.tsx
+++ b/src/features/auth/login/RecoverAccountModal.tsx
@@ -3,6 +3,7 @@ import { useEffect, useState, type ChangeEvent } from 'react'
 import RecoveryIconSvg from '@/assets/icons/RecoveryIcon.svg?react'
 import RecoveryVerifyIconSvg from '@/assets/icons/RecoveryVerifyIcon.svg?react'
 import CheckToastIconSvg from '@/assets/icons/checkToast.svg?react'
+import CodeVerification from '@/components/common/CodeVerification'
 import Button from '@/components/ui/button'
 import Modal from '@/components/ui/modal/Modal'
 import Popup from '@/components/ui/modal/Popup'
@@ -16,12 +17,8 @@ type RecoverAccountModalProps = {
 
 const INITIAL_TIMER = 300
 
-const formatTime = (seconds: number) => {
-  const minute = Math.floor(seconds / 60)
-  const second = seconds % 60
-
-  return `${String(minute).padStart(2, '0')}:${String(second).padStart(2, '0')}`
-}
+// TODO: API 연동 시 제거
+const MOCK_VERIFY_CODE = '123456'
 
 const RecoverAccountModal = ({ isOpen, onClose }: RecoverAccountModalProps) => {
   const [step, setStep] = useState<RecoverStep>('inactive')
@@ -33,8 +30,6 @@ const RecoverAccountModal = ({ isOpen, onClose }: RecoverAccountModalProps) => {
   const [isSendMessageVisible, setIsSendMessageVisible] = useState(false)
   const [isCompletePopupVisible, setIsCompletePopupVisible] = useState(false)
   const [timeLeft, setTimeLeft] = useState(INITIAL_TIMER)
-
-  const hasCodeError = Boolean(codeErrorMessage)
 
   useEffect(() => {
     if (!isOpen) {
@@ -51,7 +46,13 @@ const RecoverAccountModal = ({ isOpen, onClose }: RecoverAccountModalProps) => {
   }, [isOpen])
 
   useEffect(() => {
-    if (!isOpen || step !== 'verify' || !isCodeSent || timeLeft <= 0) {
+    if (
+      !isOpen ||
+      step !== 'verify' ||
+      !isCodeSent ||
+      isCodeVerified ||
+      timeLeft <= 0
+    ) {
       return
     }
 
@@ -61,13 +62,12 @@ const RecoverAccountModal = ({ isOpen, onClose }: RecoverAccountModalProps) => {
           window.clearInterval(timer)
           return 0
         }
-
         return prev - 1
       })
     }, 1000)
 
     return () => window.clearInterval(timer)
-  }, [isOpen, step, isCodeSent, timeLeft])
+  }, [isOpen, step, isCodeSent, isCodeVerified, timeLeft])
 
   useEffect(() => {
     if (!isSendMessageVisible) {
@@ -92,7 +92,7 @@ const RecoverAccountModal = ({ isOpen, onClose }: RecoverAccountModalProps) => {
   const handleCodeChange = (e: ChangeEvent<HTMLInputElement>) => {
     setCode(e.target.value)
 
-    if (hasCodeError) {
+    if (codeErrorMessage) {
       setCodeErrorMessage('')
     }
 
@@ -133,7 +133,8 @@ const RecoverAccountModal = ({ isOpen, onClose }: RecoverAccountModalProps) => {
       return
     }
 
-    if (code.trim() !== '123456') {
+    // TODO: API 연동 시 아래 mock 로직 제거
+    if (code.trim() !== MOCK_VERIFY_CODE) {
       setCodeErrorMessage('인증코드가 일치하지 않습니다.')
       setIsCodeVerified(false)
       return
@@ -179,7 +180,7 @@ const RecoverAccountModal = ({ isOpen, onClose }: RecoverAccountModalProps) => {
     }
 
     return (
-      <div className="border-ui-gray-200 bg-ui-gray-100 fixed top-[calc(50vh-289px)] left-1/2 z-[1001] flex h-[48px] w-fit -translate-x-1/2 items-center gap-[12px] rounded-[4px] border px-[16px] py-[12px] whitespace-nowrap shadow-[4px_4px_4px_rgba(131,131,131,0.25)]">
+      <div className="border-ui-gray-200 bg-ui-gray-100 fixed top-4 left-1/2 z-[1001] flex h-[48px] w-fit -translate-x-1/2 items-center gap-[12px] rounded-[4px] border px-[16px] py-[12px] whitespace-nowrap shadow-[4px_4px_4px_rgba(131,131,131,0.25)]">
         <CheckToastIconSvg className="h-[24px] w-[24px] shrink-0" />
         <span className="text-ui-gray-600 text-[14px] leading-[140%] font-normal tracking-[-0.03em]">
           전송 완료! 이메일을 확인해주세요.
@@ -193,19 +194,30 @@ const RecoverAccountModal = ({ isOpen, onClose }: RecoverAccountModalProps) => {
       <Popup
         isOpen={isOpen && isCompletePopupVisible}
         onClose={handleCompletePopupClose}
-        width="w-[410px]"
+        width="w-[396px]"
         isNested
       >
-        <div className="flex flex-col items-center px-[32px] py-[40px] text-center">
-          <CheckToastIconSvg className="mb-[20px] h-[40px] w-[40px]" />
+        <div className="flex flex-col items-center gap-[10px] p-[24px] text-center">
+          <div className="flex h-[24px] w-[24px] items-center justify-center rounded-full bg-[#14C786]">
+            <svg width="13" height="9" viewBox="0 0 13 9" fill="none">
+              <path
+                d="M1.5 4.5L5 8L11.5 1"
+                stroke="#FAFAFA"
+                strokeWidth="1.5"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              />
+            </svg>
+          </div>
 
-          <h2 className="text-ui-gray-primary mb-[16px] text-[20px] leading-[140%] font-bold tracking-[-0.03em]">
-            계정 복구 완료!
-          </h2>
-
-          <p className="text-ui-gray-600 text-[14px] leading-[140%] font-normal tracking-[-0.03em]">
-            지금 바로 로그인해 보세요
-          </p>
+          <div className="flex flex-col gap-[12px]">
+            <p className="text-ui-gray-primary text-[20px] leading-[140%] font-bold tracking-[-0.03em]">
+              계정 복구 완료!
+            </p>
+            <p className="text-ui-gray-600 text-[14px] leading-[140%] font-normal tracking-[-0.03em]">
+              지금 바로 로그인해 보세요
+            </p>
+          </div>
         </div>
       </Popup>
     )
@@ -221,7 +233,6 @@ const RecoverAccountModal = ({ isOpen, onClose }: RecoverAccountModalProps) => {
             <h2 className="text-ui-gray-primary text-[20px] leading-[140%] font-bold tracking-[-0.03em]">
               해당 계정은 탈퇴된 상태예요
             </h2>
-
             <p className="text-ui-gray-600 text-[14px] leading-[140%] font-normal tracking-[-0.03em]">
               2025년 6월 20일 이후, 계정 정보는 완전히 삭제돼요.
               <br />
@@ -239,7 +250,7 @@ const RecoverAccountModal = ({ isOpen, onClose }: RecoverAccountModalProps) => {
 
   const renderVerifyContent = () => {
     return (
-      <div className="flex flex-col gap-[32px] px-[24px] pb-[24px]">
+      <div className="flex flex-col gap-[40px] px-[24px] pb-[24px]">
         <div className="flex flex-col items-center gap-[16px] text-center">
           <RecoveryVerifyIconSvg className="h-[28px] w-[28px]" />
 
@@ -247,92 +258,31 @@ const RecoverAccountModal = ({ isOpen, onClose }: RecoverAccountModalProps) => {
             <h2 className="text-ui-gray-primary text-[20px] leading-[140%] font-bold tracking-[-0.03em]">
               계정 다시 사용하기
             </h2>
-
             <p className="text-ui-gray-600 text-[14px] leading-[140%] font-normal tracking-[-0.03em]">
               입력하신 이메일로 인증번호를 보내드릴게요.
             </p>
           </div>
         </div>
 
-        <div className="flex flex-col gap-[24px]">
-          <div className="flex flex-col gap-[12px]">
-            <label
-              htmlFor="recover-email"
-              className="text-ui-gray-primary text-[16px] leading-[140%] font-normal tracking-[-0.03em]"
-            >
-              이메일<span className="text-other-red">*</span>
-            </label>
-
-            <div className="flex gap-[8px]">
-              <input
-                id="recover-email"
-                type="email"
-                value={email}
-                onChange={handleEmailChange}
-                placeholder="가입한 이메일을 입력해 주세요."
-                className="text-ui-gray-primary placeholder:text-ui-gray-disabled border-ui-gray-disabled h-[48px] flex-1 rounded-[4px] border px-[16px] text-[14px] leading-[17px] outline-none"
-              />
-
-              <Button
-                type="button"
-                variant="ghost"
-                size="sm"
-                className="!text-ui-gray-700 !border-ui-gray-disabled !bg-ui-gray-200 !h-[48px] !w-[112px] !rounded-[4px] !border !px-0 !py-0 !text-[16px] !leading-[140%] !font-semibold"
-                onClick={handleSendCodeBtnClick}
-              >
-                인증코드전송
-              </Button>
-            </div>
-          </div>
-
-          <div className="flex flex-col gap-[12px]">
-            <div className="flex gap-[8px]">
-              <div className="relative flex-1">
-                <input
-                  type="text"
-                  value={code}
-                  onChange={handleCodeChange}
-                  placeholder="인증번호를 입력해주세요"
-                  className={`text-ui-gray-primary placeholder:text-ui-gray-disabled h-[48px] w-full rounded-[4px] border px-[16px] pr-[64px] text-[14px] leading-[17px] outline-none ${
-                    hasCodeError
-                      ? 'border-other-red'
-                      : isCodeVerified
-                        ? 'border-other-green'
-                        : 'border-ui-gray-disabled'
-                  }`}
-                />
-
-                {isCodeSent && (
-                  <span className="text-other-red absolute top-1/2 right-[16px] -translate-y-1/2 text-[14px] leading-[17px] tracking-[-0.03em]">
-                    {formatTime(timeLeft)}
-                  </span>
-                )}
-              </div>
-
-              <Button
-                type="button"
-                variant="ghost"
-                size="sm"
-                className="!text-ui-gray-700 !border-ui-gray-disabled !bg-ui-gray-200 !h-[48px] !w-[112px] !rounded-[4px] !border !px-0 !py-0 !text-[16px] !leading-[140%] !font-semibold"
-                onClick={handleVerifyCodeBtnClick}
-              >
-                인증코드확인
-              </Button>
-            </div>
-
-            {hasCodeError && (
-              <p className="text-other-red text-[14px] leading-[140%] font-normal tracking-[-0.03em]">
-                {codeErrorMessage}
-              </p>
-            )}
-
-            {isCodeVerified && !hasCodeError && (
-              <p className="text-other-green text-[14px] leading-[140%] font-normal tracking-[-0.03em]">
-                인증코드가 일치합니다.
-              </p>
-            )}
-          </div>
-        </div>
+        <CodeVerification
+          label="이메일"
+          required
+          targetInputId="recover-account-email"
+          targetValue={email}
+          onTargetChange={handleEmailChange}
+          targetPlaceholder="가입한 이메일을 입력해 주세요."
+          targetInputType="email"
+          verificationCodeInputId="recover-account-code"
+          verificationCode={code}
+          onVerificationCodeChange={handleCodeChange}
+          verificationCodePlaceholder="인증번호 6자리를 입력해주세요"
+          onSendCode={handleSendCodeBtnClick}
+          onVerifyCode={handleVerifyCodeBtnClick}
+          isCodeSent={isCodeSent}
+          isCodeVerified={isCodeVerified}
+          errorMessage={codeErrorMessage}
+          timeLeft={timeLeft}
+        />
 
         <Button variant="fill" size="full" onClick={handleCompleteBtnClick}>
           확인

--- a/src/features/auth/login/RecoverAccountModal.tsx
+++ b/src/features/auth/login/RecoverAccountModal.tsx
@@ -1,4 +1,5 @@
-import { useEffect, useState, type ChangeEvent } from 'react'
+import { useEffect, useState } from 'react'
+import { useNavigate } from 'react-router-dom'
 
 import RecoveryIconSvg from '@/assets/icons/RecoveryIcon.svg?react'
 import RecoveryVerifyIconSvg from '@/assets/icons/RecoveryVerifyIcon.svg?react'
@@ -7,6 +8,7 @@ import CodeVerification from '@/components/common/CodeVerification'
 import Button from '@/components/ui/button'
 import Modal from '@/components/ui/modal/Modal'
 import Popup from '@/components/ui/modal/Popup'
+import { useRecoverAccountVerification } from '@/hooks/useRecoverAccountVerification'
 
 type RecoverStep = 'inactive' | 'verify'
 
@@ -15,185 +17,133 @@ type RecoverAccountModalProps = {
   onClose: () => void
 }
 
-const INITIAL_TIMER = 300
-
-// TODO: API 연동 시 제거
-const MOCK_VERIFY_CODE = '123456'
-
 const RecoverAccountModal = ({ isOpen, onClose }: RecoverAccountModalProps) => {
+  const navigate = useNavigate()
   const [step, setStep] = useState<RecoverStep>('inactive')
-  const [email, setEmail] = useState('')
-  const [code, setCode] = useState('')
-  const [isCodeSent, setIsCodeSent] = useState(false)
-  const [isCodeVerified, setIsCodeVerified] = useState(false)
-  const [codeErrorMessage, setCodeErrorMessage] = useState('')
-  const [isSendMessageVisible, setIsSendMessageVisible] = useState(false)
-  const [isCompletePopupVisible, setIsCompletePopupVisible] = useState(false)
-  const [timeLeft, setTimeLeft] = useState(INITIAL_TIMER)
+
+  const {
+    email,
+    code,
+    isCodeSent,
+    isCodeVerified,
+    errorMessage,
+    isSendToastVisible,
+    isCompletePopupVisible,
+    formattedTime,
+    handleEmailChange,
+    handleCodeChange,
+    handleSendCode,
+    handleVerifyCode,
+    handleCompleteButtonClick,
+    closeCompletePopup,
+  } = useRecoverAccountVerification({ isOpen })
 
   useEffect(() => {
     if (!isOpen) {
       setStep('inactive')
-      setEmail('')
-      setCode('')
-      setIsCodeSent(false)
-      setIsCodeVerified(false)
-      setCodeErrorMessage('')
-      setIsSendMessageVisible(false)
-      setIsCompletePopupVisible(false)
-      setTimeLeft(INITIAL_TIMER)
     }
   }, [isOpen])
 
   useEffect(() => {
-    if (
-      !isOpen ||
-      step !== 'verify' ||
-      !isCodeSent ||
-      isCodeVerified ||
-      timeLeft <= 0
-    ) {
-      return
-    }
-
-    const timer = window.setInterval(() => {
-      setTimeLeft((prev) => {
-        if (prev <= 1) {
-          window.clearInterval(timer)
-          return 0
-        }
-        return prev - 1
-      })
-    }, 1000)
-
-    return () => window.clearInterval(timer)
-  }, [isOpen, step, isCodeSent, isCodeVerified, timeLeft])
-
-  useEffect(() => {
-    if (!isSendMessageVisible) {
-      return
-    }
+    if (!isCompletePopupVisible) return
 
     const timer = window.setTimeout(() => {
-      setIsSendMessageVisible(false)
-    }, 2500)
+      closeCompletePopup()
+      onClose()
+      navigate('/login')
+    }, 2000)
 
     return () => window.clearTimeout(timer)
-  }, [isSendMessageVisible])
+  }, [isCompletePopupVisible, closeCompletePopup, navigate, onClose])
 
-  const handleRecoverStartBtnClick = () => {
+  const handleRecoverStartButtonClick = () => {
     setStep('verify')
   }
 
-  const handleEmailChange = (e: ChangeEvent<HTMLInputElement>) => {
-    setEmail(e.target.value)
-  }
-
-  const handleCodeChange = (e: ChangeEvent<HTMLInputElement>) => {
-    setCode(e.target.value)
-
-    if (codeErrorMessage) {
-      setCodeErrorMessage('')
-    }
-
-    if (isCodeVerified) {
-      setIsCodeVerified(false)
-    }
-  }
-
-  const handleSendCodeBtnClick = () => {
-    if (!email.trim()) {
-      return
-    }
-
-    setIsCodeSent(true)
-    setIsCodeVerified(false)
-    setCodeErrorMessage('')
-    setCode('')
-    setTimeLeft(INITIAL_TIMER)
-    setIsSendMessageVisible(true)
-  }
-
-  const handleVerifyCodeBtnClick = () => {
-    if (!isCodeSent) {
-      setCodeErrorMessage('인증코드를 먼저 전송해주세요.')
-      setIsCodeVerified(false)
-      return
-    }
-
-    if (!code.trim()) {
-      setCodeErrorMessage('인증코드를 입력해주세요.')
-      setIsCodeVerified(false)
-      return
-    }
-
-    if (timeLeft <= 0) {
-      setCodeErrorMessage('인증 시간이 만료되었습니다. 다시 전송해주세요.')
-      setIsCodeVerified(false)
-      return
-    }
-
-    // TODO: API 연동 시 아래 mock 로직 제거
-    if (code.trim() !== MOCK_VERIFY_CODE) {
-      setCodeErrorMessage('인증코드가 일치하지 않습니다.')
-      setIsCodeVerified(false)
-      return
-    }
-
-    setCodeErrorMessage('')
-    setIsCodeVerified(true)
-  }
-
-  const handleCompleteBtnClick = () => {
-    if (!isCodeSent) {
-      setCodeErrorMessage('인증코드를 먼저 전송해주세요.')
-      return
-    }
-
-    if (!code.trim()) {
-      setCodeErrorMessage('인증코드를 입력해주세요.')
-      return
-    }
-
-    if (timeLeft <= 0) {
-      setCodeErrorMessage('인증 시간이 만료되었습니다. 다시 전송해주세요.')
-      return
-    }
-
-    if (!isCodeVerified) {
-      setCodeErrorMessage('인증코드 확인을 완료해주세요.')
-      return
-    }
-
-    setCodeErrorMessage('')
-    setIsCompletePopupVisible(true)
-  }
-
-  const handleCompletePopupClose = () => {
-    setIsCompletePopupVisible(false)
-    onClose()
-  }
-
-  const renderSendSuccessMessage = () => {
-    if (!isOpen || step !== 'verify' || !isSendMessageVisible) {
-      return null
-    }
-
+  const renderInactiveContent = () => {
     return (
-      <div className="border-ui-gray-200 bg-ui-gray-100 fixed top-4 left-1/2 z-[1001] flex h-[48px] w-fit -translate-x-1/2 items-center gap-[12px] rounded-[4px] border px-[16px] py-[12px] whitespace-nowrap shadow-[4px_4px_4px_rgba(131,131,131,0.25)]">
-        <CheckToastIconSvg className="h-[24px] w-[24px] shrink-0" />
-        <span className="text-ui-gray-600 text-[14px] leading-[140%] font-normal tracking-[-0.03em]">
-          전송 완료! 이메일을 확인해주세요.
-        </span>
+      <div className="flex flex-col gap-[32px] px-[24px] pb-[24px]">
+        <div className="flex flex-col items-center gap-[16px] text-center">
+          <RecoveryIconSvg className="h-[28px] w-[28px]" />
+          <div className="flex flex-col items-center gap-[12px]">
+            <h2 className="text-ui-gray-primary text-[20px] leading-[140%] font-bold tracking-[-0.03em]">
+              해당 계정은 탈퇴된 상태예요
+            </h2>
+            <p className="text-ui-gray-600 text-[14px] leading-[140%] font-normal tracking-[-0.03em]">
+              2025년 6월 20일 이후, 계정 정보는 완전히 삭제돼요.
+              <br />
+              계정을 다시 사용하려면 아래 버튼을 눌러 복구를 진행해주세요.
+            </p>
+          </div>
+        </div>
+
+        <Button
+          variant="fill"
+          size="full"
+          onClick={handleRecoverStartButtonClick}
+        >
+          계정 다시 사용하기
+        </Button>
       </div>
     )
   }
 
-  const renderCompletePopup = () => {
+  const renderVerifyContent = () => {
     return (
+      <div className="flex flex-col gap-[40px] px-[24px] pb-[24px]">
+        <div className="flex flex-col items-center gap-[16px] text-center">
+          <RecoveryVerifyIconSvg className="h-[28px] w-[28px]" />
+          <div className="flex flex-col items-center gap-[12px]">
+            <h2 className="text-ui-gray-primary text-[20px] leading-[140%] font-bold tracking-[-0.03em]">
+              계정 다시 사용하기
+            </h2>
+            <p className="text-ui-gray-600 text-[14px] leading-[140%] font-normal tracking-[-0.03em]">
+              입력하신 이메일로 인증번호를 보내드릴게요.
+            </p>
+          </div>
+        </div>
+
+        <CodeVerification
+          label="이메일"
+          required
+          targetInputId="recover-account-email"
+          targetValue={email}
+          onTargetChange={handleEmailChange}
+          targetPlaceholder="가입한 이메일을 입력해 주세요."
+          targetInputType="email"
+          verificationCodeInputId="recover-account-code"
+          verificationCode={code}
+          onVerificationCodeChange={handleCodeChange}
+          verificationCodePlaceholder="인증번호 6자리를 입력해주세요"
+          onSendCode={handleSendCode}
+          onVerifyCode={handleVerifyCode}
+          isCodeSent={isCodeSent}
+          isCodeVerified={isCodeVerified}
+          errorMessage={errorMessage}
+          formattedTime={formattedTime}
+        />
+
+        <Button variant="fill" size="full" onClick={handleCompleteButtonClick}>
+          확인
+        </Button>
+      </div>
+    )
+  }
+
+  return (
+    <>
+      {isSendToastVisible && (
+        <div className="border-ui-gray-200 bg-ui-gray-100 fixed top-4 left-1/2 z-[1001] flex h-[48px] w-fit -translate-x-1/2 items-center gap-[12px] rounded-[4px] border px-[16px] py-[12px] whitespace-nowrap shadow-[4px_4px_4px_rgba(131,131,131,0.25)]">
+          <CheckToastIconSvg className="h-[24px] w-[24px] shrink-0" />
+          <span className="text-ui-gray-600 text-[14px] leading-[140%] font-normal tracking-[-0.03em]">
+            전송 완료! 이메일을 확인해주세요.
+          </span>
+        </div>
+      )}
+
       <Popup
         isOpen={isOpen && isCompletePopupVisible}
-        onClose={handleCompletePopupClose}
+        onClose={closeCompletePopup}
         width="w-[396px]"
         isNested
       >
@@ -220,87 +170,12 @@ const RecoverAccountModal = ({ isOpen, onClose }: RecoverAccountModalProps) => {
           </div>
         </div>
       </Popup>
-    )
-  }
-
-  const renderInactiveContent = () => {
-    return (
-      <div className="flex flex-col gap-[32px] px-[24px] pb-[24px]">
-        <div className="flex flex-col items-center gap-[16px] text-center">
-          <RecoveryIconSvg className="h-[28px] w-[28px]" />
-
-          <div className="flex flex-col items-center gap-[12px]">
-            <h2 className="text-ui-gray-primary text-[20px] leading-[140%] font-bold tracking-[-0.03em]">
-              해당 계정은 탈퇴된 상태예요
-            </h2>
-            <p className="text-ui-gray-600 text-[14px] leading-[140%] font-normal tracking-[-0.03em]">
-              2025년 6월 20일 이후, 계정 정보는 완전히 삭제돼요.
-              <br />
-              계정을 다시 사용하려면 아래 버튼을 눌러 복구를 진행해주세요.
-            </p>
-          </div>
-        </div>
-
-        <Button variant="fill" size="full" onClick={handleRecoverStartBtnClick}>
-          계정 다시 사용하기
-        </Button>
-      </div>
-    )
-  }
-
-  const renderVerifyContent = () => {
-    return (
-      <div className="flex flex-col gap-[40px] px-[24px] pb-[24px]">
-        <div className="flex flex-col items-center gap-[16px] text-center">
-          <RecoveryVerifyIconSvg className="h-[28px] w-[28px]" />
-
-          <div className="flex flex-col items-center gap-[12px]">
-            <h2 className="text-ui-gray-primary text-[20px] leading-[140%] font-bold tracking-[-0.03em]">
-              계정 다시 사용하기
-            </h2>
-            <p className="text-ui-gray-600 text-[14px] leading-[140%] font-normal tracking-[-0.03em]">
-              입력하신 이메일로 인증번호를 보내드릴게요.
-            </p>
-          </div>
-        </div>
-
-        <CodeVerification
-          label="이메일"
-          required
-          targetInputId="recover-account-email"
-          targetValue={email}
-          onTargetChange={handleEmailChange}
-          targetPlaceholder="가입한 이메일을 입력해 주세요."
-          targetInputType="email"
-          verificationCodeInputId="recover-account-code"
-          verificationCode={code}
-          onVerificationCodeChange={handleCodeChange}
-          verificationCodePlaceholder="인증번호 6자리를 입력해주세요"
-          onSendCode={handleSendCodeBtnClick}
-          onVerifyCode={handleVerifyCodeBtnClick}
-          isCodeSent={isCodeSent}
-          isCodeVerified={isCodeVerified}
-          errorMessage={codeErrorMessage}
-          timeLeft={timeLeft}
-        />
-
-        <Button variant="fill" size="full" onClick={handleCompleteBtnClick}>
-          확인
-        </Button>
-      </div>
-    )
-  }
-
-  return (
-    <>
-      {renderSendSuccessMessage()}
-      {renderCompletePopup()}
 
       <Modal isOpen={isOpen} onClose={onClose} width="w-[396px]">
-        {step === 'inactive' &&
-          !isCompletePopupVisible &&
+        {!isCompletePopupVisible &&
+          step === 'inactive' &&
           renderInactiveContent()}
-        {step === 'verify' && !isCompletePopupVisible && renderVerifyContent()}
+        {!isCompletePopupVisible && step === 'verify' && renderVerifyContent()}
       </Modal>
     </>
   )

--- a/src/features/auth/login/RecoverAccountModal.tsx
+++ b/src/features/auth/login/RecoverAccountModal.tsx
@@ -1,0 +1,354 @@
+import { useEffect, useState, type ChangeEvent } from 'react'
+
+import RecoveryIconSvg from '@/assets/icons/RecoveryIcon.svg?react'
+import RecoveryVerifyIconSvg from '@/assets/icons/RecoveryVerifyIcon.svg?react'
+import CheckToastIconSvg from '@/assets/icons/checkToast.svg?react'
+import Button from '@/components/ui/button'
+import Modal from '@/components/ui/modal/Modal'
+
+type RecoverStep = 'inactive' | 'verify' | 'complete'
+
+type RecoverAccountModalProps = {
+  isOpen: boolean
+  onClose: () => void
+}
+
+const INITIAL_TIMER = 300
+
+const formatTime = (seconds: number) => {
+  const minute = Math.floor(seconds / 60)
+  const second = seconds % 60
+
+  return `${String(minute).padStart(2, '0')}:${String(second).padStart(2, '0')}`
+}
+
+const RecoverAccountModal = ({ isOpen, onClose }: RecoverAccountModalProps) => {
+  const [step, setStep] = useState<RecoverStep>('inactive')
+  const [email, setEmail] = useState('')
+  const [code, setCode] = useState('')
+  const [isCodeSent, setIsCodeSent] = useState(false)
+  const [isCodeVerified, setIsCodeVerified] = useState(false)
+  const [codeErrorMessage, setCodeErrorMessage] = useState('')
+  const [isSendMessageVisible, setIsSendMessageVisible] = useState(false)
+  const [timeLeft, setTimeLeft] = useState(INITIAL_TIMER)
+
+  const hasCodeError = Boolean(codeErrorMessage)
+
+  useEffect(() => {
+    if (!isOpen) {
+      setStep('inactive')
+      setEmail('')
+      setCode('')
+      setIsCodeSent(false)
+      setIsCodeVerified(false)
+      setCodeErrorMessage('')
+      setIsSendMessageVisible(false)
+      setTimeLeft(INITIAL_TIMER)
+    }
+  }, [isOpen])
+
+  useEffect(() => {
+    if (!isOpen || step !== 'verify' || !isCodeSent || timeLeft <= 0) {
+      return
+    }
+
+    const timer = window.setInterval(() => {
+      setTimeLeft((prev) => {
+        if (prev <= 1) {
+          window.clearInterval(timer)
+          return 0
+        }
+
+        return prev - 1
+      })
+    }, 1000)
+
+    return () => window.clearInterval(timer)
+  }, [isOpen, step, isCodeSent, timeLeft])
+
+  useEffect(() => {
+    if (!isSendMessageVisible) {
+      return
+    }
+
+    const timer = window.setTimeout(() => {
+      setIsSendMessageVisible(false)
+    }, 2500)
+
+    return () => window.clearTimeout(timer)
+  }, [isSendMessageVisible])
+
+  const handleRecoverStartBtnClick = () => {
+    setStep('verify')
+  }
+
+  const handleEmailChange = (e: ChangeEvent<HTMLInputElement>) => {
+    setEmail(e.target.value)
+  }
+
+  const handleCodeChange = (e: ChangeEvent<HTMLInputElement>) => {
+    setCode(e.target.value)
+
+    if (hasCodeError) {
+      setCodeErrorMessage('')
+    }
+
+    if (isCodeVerified) {
+      setIsCodeVerified(false)
+    }
+  }
+
+  const handleSendCodeBtnClick = () => {
+    if (!email.trim()) {
+      return
+    }
+
+    setIsCodeSent(true)
+    setIsCodeVerified(false)
+    setCodeErrorMessage('')
+    setCode('')
+    setTimeLeft(INITIAL_TIMER)
+    setIsSendMessageVisible(true)
+  }
+
+  const handleVerifyCodeBtnClick = () => {
+    if (!isCodeSent) {
+      setCodeErrorMessage('인증코드를 먼저 전송해주세요.')
+      setIsCodeVerified(false)
+      return
+    }
+
+    if (!code.trim()) {
+      setCodeErrorMessage('인증코드를 입력해주세요.')
+      setIsCodeVerified(false)
+      return
+    }
+
+    if (timeLeft <= 0) {
+      setCodeErrorMessage('인증 시간이 만료되었습니다. 다시 전송해주세요.')
+      setIsCodeVerified(false)
+      return
+    }
+
+    if (code.trim() !== '123456') {
+      setCodeErrorMessage('인증코드가 일치하지 않습니다.')
+      setIsCodeVerified(false)
+      return
+    }
+
+    setCodeErrorMessage('')
+    setIsCodeVerified(true)
+  }
+
+  const handleCompleteBtnClick = () => {
+    if (!isCodeSent) {
+      setCodeErrorMessage('인증코드를 먼저 전송해주세요.')
+      return
+    }
+
+    if (!code.trim()) {
+      setCodeErrorMessage('인증코드를 입력해주세요.')
+      return
+    }
+
+    if (timeLeft <= 0) {
+      setCodeErrorMessage('인증 시간이 만료되었습니다. 다시 전송해주세요.')
+      return
+    }
+
+    if (!isCodeVerified) {
+      setCodeErrorMessage('인증코드 확인을 완료해주세요.')
+      return
+    }
+
+    setCodeErrorMessage('')
+    setStep('complete')
+  }
+
+  const handleCompletePopupConfirmBtnClick = () => {
+    onClose()
+  }
+
+  const renderSendSuccessMessage = () => {
+    if (!isOpen || step !== 'verify' || !isSendMessageVisible) {
+      return null
+    }
+
+    return (
+      <div className="border-ui-gray-200 bg-ui-gray-100 fixed top-[calc(50vh-289px)] left-1/2 z-[1001] flex h-[48px] w-fit -translate-x-1/2 items-center gap-[12px] rounded-[4px] border px-[16px] py-[12px] whitespace-nowrap shadow-[4px_4px_4px_rgba(131,131,131,0.25)]">
+        <CheckToastIconSvg className="h-[24px] w-[24px] shrink-0" />
+        <span className="text-ui-gray-600 text-[14px] leading-[140%] font-normal tracking-[-0.03em]">
+          전송 완료! 이메일을 확인해주세요.
+        </span>
+      </div>
+    )
+  }
+
+  const renderInactiveContent = () => {
+    return (
+      <div className="flex flex-col gap-[32px] px-[24px] pb-[24px]">
+        <div className="flex flex-col items-center gap-[16px] text-center">
+          <RecoveryIconSvg className="h-[28px] w-[28px]" />
+
+          <div className="flex flex-col items-center gap-[12px]">
+            <h2 className="text-ui-gray-primary text-[20px] leading-[140%] font-bold tracking-[-0.03em]">
+              해당 계정은 탈퇴된 상태예요
+            </h2>
+
+            <p className="text-ui-gray-600 text-[14px] leading-[140%] font-normal tracking-[-0.03em]">
+              2025년 6월 20일 이후, 계정 정보는 완전히 삭제돼요.
+              <br />
+              계정을 다시 사용하려면 아래 버튼을 눌러 복구를 진행해주세요.
+            </p>
+          </div>
+        </div>
+
+        <Button variant="fill" size="full" onClick={handleRecoverStartBtnClick}>
+          계정 다시 사용하기
+        </Button>
+      </div>
+    )
+  }
+
+  const renderVerifyContent = () => {
+    return (
+      <div className="flex flex-col gap-[32px] px-[24px] pb-[24px]">
+        <div className="flex flex-col items-center gap-[16px] text-center">
+          <RecoveryVerifyIconSvg className="h-[28px] w-[28px]" />
+
+          <div className="flex flex-col items-center gap-[12px]">
+            <h2 className="text-ui-gray-primary text-[20px] leading-[140%] font-bold tracking-[-0.03em]">
+              계정 다시 사용하기
+            </h2>
+
+            <p className="text-ui-gray-600 text-[14px] leading-[140%] font-normal tracking-[-0.03em]">
+              입력하신 이메일로 인증번호를 보내드릴게요.
+            </p>
+          </div>
+        </div>
+
+        <div className="flex flex-col gap-[24px]">
+          <div className="flex flex-col gap-[12px]">
+            <label
+              htmlFor="recover-email"
+              className="text-ui-gray-primary text-[16px] leading-[140%] font-normal tracking-[-0.03em]"
+            >
+              이메일<span className="text-other-red">*</span>
+            </label>
+
+            <div className="flex gap-[8px]">
+              <input
+                id="recover-email"
+                type="email"
+                value={email}
+                onChange={handleEmailChange}
+                placeholder="가입한 이메일을 입력해 주세요."
+                className="text-ui-gray-primary placeholder:text-ui-gray-disabled border-ui-gray-disabled h-[48px] flex-1 rounded-[4px] border px-[16px] text-[14px] leading-[17px] outline-none"
+              />
+
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                className="!text-ui-gray-700 !border-ui-gray-disabled !bg-ui-gray-200 !h-[48px] !w-[112px] !rounded-[4px] !border !px-0 !py-0 !text-[16px] !leading-[140%] !font-semibold"
+                onClick={handleSendCodeBtnClick}
+              >
+                인증코드전송
+              </Button>
+            </div>
+          </div>
+
+          <div className="flex flex-col gap-[12px]">
+            <div className="flex gap-[8px]">
+              <div className="relative flex-1">
+                <input
+                  type="text"
+                  value={code}
+                  onChange={handleCodeChange}
+                  placeholder="인증번호를 입력해주세요"
+                  className={`text-ui-gray-primary placeholder:text-ui-gray-disabled h-[48px] w-full rounded-[4px] border px-[16px] pr-[64px] text-[14px] leading-[17px] outline-none ${
+                    hasCodeError
+                      ? 'border-other-red'
+                      : isCodeVerified
+                        ? 'border-other-green'
+                        : 'border-ui-gray-disabled'
+                  }`}
+                />
+
+                {isCodeSent && (
+                  <span className="text-other-red absolute top-1/2 right-[16px] -translate-y-1/2 text-[14px] leading-[17px] tracking-[-0.03em]">
+                    {formatTime(timeLeft)}
+                  </span>
+                )}
+              </div>
+
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                className="!text-ui-gray-700 !border-ui-gray-disabled !bg-ui-gray-200 !h-[48px] !w-[112px] !rounded-[4px] !border !px-0 !py-0 !text-[16px] !leading-[140%] !font-semibold"
+                onClick={handleVerifyCodeBtnClick}
+              >
+                인증코드확인
+              </Button>
+            </div>
+
+            {hasCodeError && (
+              <p className="text-other-red text-[14px] leading-[140%] font-normal tracking-[-0.03em]">
+                {codeErrorMessage}
+              </p>
+            )}
+
+            {isCodeVerified && !hasCodeError && (
+              <p className="text-other-green text-[14px] leading-[140%] font-normal tracking-[-0.03em]">
+                인증코드가 일치합니다.
+              </p>
+            )}
+          </div>
+        </div>
+
+        <Button variant="fill" size="full" onClick={handleCompleteBtnClick}>
+          확인
+        </Button>
+      </div>
+    )
+  }
+
+  const renderCompleteContent = () => {
+    return (
+      <div className="flex flex-col items-center gap-[12px] px-[24px] pb-[24px] text-center">
+        <CheckToastIconSvg className="h-[24px] w-[24px]" />
+
+        <h2 className="text-ui-gray-primary text-[20px] leading-[140%] font-bold tracking-[-0.03em]">
+          계정 복구 완료!
+        </h2>
+
+        <p className="text-ui-gray-600 text-[14px] leading-[140%] font-normal tracking-[-0.03em]">
+          지금 바로 로그인해 보세요
+        </p>
+
+        <Button
+          variant="fill"
+          size="full"
+          onClick={handleCompletePopupConfirmBtnClick}
+        >
+          확인
+        </Button>
+      </div>
+    )
+  }
+
+  return (
+    <>
+      {renderSendSuccessMessage()}
+
+      <Modal isOpen={isOpen} onClose={onClose} width="w-[396px]">
+        {step === 'inactive' && renderInactiveContent()}
+        {step === 'verify' && renderVerifyContent()}
+        {step === 'complete' && renderCompleteContent()}
+      </Modal>
+    </>
+  )
+}
+
+export default RecoverAccountModal

--- a/src/hooks/useModalScroll.ts
+++ b/src/hooks/useModalScroll.ts
@@ -6,11 +6,25 @@ import { useEffect } from 'react'
  */
 export const useModalScroll = (isOpen: boolean) => {
   useEffect(() => {
-    if (isOpen) {
-      document.body.style.overflow = 'hidden'
+    if (!isOpen) {
+      return
     }
+
+    const scrollBarWidth =
+      window.innerWidth - document.documentElement.clientWidth
+
+    const originalOverflow = document.body.style.overflow
+    const originalPaddingRight = document.body.style.paddingRight
+
+    document.body.style.overflow = 'hidden'
+
+    if (scrollBarWidth > 0) {
+      document.body.style.paddingRight = `${scrollBarWidth}px`
+    }
+
     return () => {
-      document.body.style.overflow = ''
+      document.body.style.overflow = originalOverflow
+      document.body.style.paddingRight = originalPaddingRight
     }
   }, [isOpen])
 }

--- a/src/hooks/useRecoverAccountVerification.ts
+++ b/src/hooks/useRecoverAccountVerification.ts
@@ -1,0 +1,166 @@
+import { useCallback, useEffect, useState } from 'react'
+
+import { useTimer } from '@/hooks/useTimer'
+
+const INITIAL_TIME = 300
+
+// TODO: API 연동 시 제거
+const MOCK_VERIFY_CODE = '123456'
+
+type UseRecoverAccountVerificationParams = {
+  isOpen: boolean
+}
+
+export const useRecoverAccountVerification = ({
+  isOpen,
+}: UseRecoverAccountVerificationParams) => {
+  const [email, setEmail] = useState('')
+  const [code, setCode] = useState('')
+  const [isCodeSent, setIsCodeSent] = useState(false)
+  const [isCodeVerified, setIsCodeVerified] = useState(false)
+  const [errorMessage, setErrorMessage] = useState('')
+  const [isSendToastVisible, setIsSendToastVisible] = useState(false)
+  const [isCompletePopupVisible, setIsCompletePopupVisible] = useState(false)
+
+  const { formattedTime, isExpired, startTimer, stopTimer, resetTimer } =
+    useTimer(INITIAL_TIME)
+
+  const resetVerificationState = useCallback(() => {
+    setEmail('')
+    setCode('')
+    setIsCodeSent(false)
+    setIsCodeVerified(false)
+    setErrorMessage('')
+    setIsSendToastVisible(false)
+    setIsCompletePopupVisible(false)
+    resetTimer()
+  }, [resetTimer])
+
+  useEffect(() => {
+    if (!isOpen) {
+      resetVerificationState()
+    }
+  }, [isOpen, resetVerificationState])
+
+  useEffect(() => {
+    if (!isSendToastVisible) return
+
+    const timer = window.setTimeout(() => {
+      setIsSendToastVisible(false)
+    }, 2500)
+
+    return () => window.clearTimeout(timer)
+  }, [isSendToastVisible])
+
+  const handleEmailChange = (value: string) => {
+    setEmail(value)
+
+    if (isCodeSent) {
+      setIsCodeSent(false)
+    }
+
+    if (isCodeVerified) {
+      setIsCodeVerified(false)
+    }
+
+    if (errorMessage) {
+      setErrorMessage('')
+    }
+
+    setCode('')
+    resetTimer()
+  }
+
+  const handleCodeChange = (value: string) => {
+    setCode(value)
+
+    if (errorMessage) {
+      setErrorMessage('')
+    }
+
+    if (isCodeVerified) {
+      setIsCodeVerified(false)
+    }
+  }
+
+  const handleSendCode = () => {
+    if (!email.trim()) return
+
+    setIsCodeSent(true)
+    setIsCodeVerified(false)
+    setErrorMessage('')
+    setCode('')
+    startTimer()
+    setIsSendToastVisible(true)
+  }
+
+  const validateCode = () => {
+    if (!isCodeSent) {
+      setErrorMessage('인증코드를 먼저 전송해주세요.')
+      return false
+    }
+
+    if (!code.trim()) {
+      setErrorMessage('인증코드를 입력해주세요.')
+      return false
+    }
+
+    if (isExpired) {
+      setErrorMessage('인증 시간이 만료되었습니다. 다시 전송해주세요.')
+      return false
+    }
+
+    return true
+  }
+
+  const handleVerifyCode = () => {
+    if (!validateCode()) {
+      setIsCodeVerified(false)
+      return
+    }
+
+    // TODO: API 연동 시 아래 mock 로직 제거
+    if (code.trim() !== MOCK_VERIFY_CODE) {
+      setErrorMessage('인증코드가 일치하지 않습니다.')
+      setIsCodeVerified(false)
+      return
+    }
+
+    setErrorMessage('')
+    setIsCodeVerified(true)
+    stopTimer()
+  }
+
+  const handleCompleteButtonClick = () => {
+    if (!validateCode()) return
+
+    if (!isCodeVerified) {
+      setErrorMessage('인증코드 확인을 완료해주세요.')
+      return
+    }
+
+    setErrorMessage('')
+    setIsCompletePopupVisible(true)
+  }
+
+  const closeCompletePopup = () => {
+    setIsCompletePopupVisible(false)
+  }
+
+  return {
+    email,
+    code,
+    isCodeSent,
+    isCodeVerified,
+    errorMessage,
+    isSendToastVisible,
+    isCompletePopupVisible,
+    formattedTime,
+    handleEmailChange,
+    handleCodeChange,
+    handleSendCode,
+    handleVerifyCode,
+    handleCompleteButtonClick,
+    closeCompletePopup,
+  }
+}

--- a/src/hooks/useTimer.ts
+++ b/src/hooks/useTimer.ts
@@ -1,0 +1,45 @@
+import { useCallback, useEffect, useState } from 'react'
+
+export const useTimer = (initialSeconds: number) => {
+  const [timeLeft, setTimeLeft] = useState(initialSeconds)
+  const [isActive, setIsActive] = useState(false)
+
+  const startTimer = useCallback(() => {
+    setTimeLeft(initialSeconds)
+    setIsActive(true)
+  }, [initialSeconds])
+
+  const stopTimer = useCallback(() => {
+    setIsActive(false)
+  }, [])
+
+  const resetTimer = useCallback(() => {
+    setIsActive(false)
+    setTimeLeft(initialSeconds)
+  }, [initialSeconds])
+
+  useEffect(() => {
+    if (!isActive || timeLeft <= 0) return
+
+    const timer = window.setTimeout(() => {
+      setTimeLeft((prev) => prev - 1)
+    }, 1000)
+
+    return () => window.clearTimeout(timer)
+  }, [isActive, timeLeft])
+
+  const min = Math.floor(timeLeft / 60)
+  const sec = timeLeft % 60
+  const formattedTime = `${String(min).padStart(2, '0')}:${String(sec).padStart(2, '0')}`
+  const isExpired = timeLeft <= 0
+
+  return {
+    timeLeft,
+    formattedTime,
+    isActive,
+    isExpired,
+    startTimer,
+    stopTimer,
+    resetTimer,
+  }
+}

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -1,7 +1,9 @@
+import { useState } from 'react'
 import { Link } from 'react-router-dom'
 
 import logoImg from '@/assets/images/logo.png'
 import { ROUTES_PATHS } from '@/constants/routesPaths'
+import RecoverAccountModal from '@/features/auth/login/RecoverAccountModal'
 import LoginForm from '@/features/auth/login/LoginForm'
 import SocialLoginButton from '@/features/auth/login/SocialLoginButton'
 
@@ -13,6 +15,8 @@ type SubmitLoginParams = {
 type Provider = 'kakao' | 'naver'
 
 const LoginPage = () => {
+  const [isRecoverModalOpen, setIsRecoverModalOpen] = useState(false)
+
   const handleSocialLoginBtnClick = ({ provider }: { provider: Provider }) => {
     void provider
   }
@@ -20,6 +24,7 @@ const LoginPage = () => {
   const handleLoginBtnClick = ({ email, password }: SubmitLoginParams) => {
     void email
     void password
+    // TODO: 로그인 API 연동 후 탈퇴 계정 응답일 때만 복구 모달을 오픈합니다.
   }
 
   const handleFindIdBtnClick = () => {}
@@ -32,7 +37,6 @@ const LoginPage = () => {
         <div className="flex w-[348px] flex-col gap-[64px]">
           <div className="flex flex-col items-center gap-[27px]">
             <img src={logoImg} alt="오즈코딩스쿨" width={180} height={24} />
-
             <div className="flex items-center gap-[12px] text-[16px] leading-[140%] tracking-[-0.03em]">
               <span className="text-ui-gray-600">아직 회원이 아니신가요?</span>
               <Link
@@ -55,7 +59,6 @@ const LoginPage = () => {
                 onClick={() => handleSocialLoginBtnClick({ provider: 'naver' })}
               />
             </div>
-
             <LoginForm
               onSubmit={handleLoginBtnClick}
               onFindId={handleFindIdBtnClick}
@@ -64,6 +67,11 @@ const LoginPage = () => {
           </div>
         </div>
       </div>
+
+      <RecoverAccountModal
+        isOpen={isRecoverModalOpen}
+        onClose={() => setIsRecoverModalOpen(false)}
+      />
     </div>
   )
 }

--- a/src/pages/TestPage.tsx
+++ b/src/pages/TestPage.tsx
@@ -5,19 +5,24 @@ import ExamEmptyState from '@/components/exam/ExamEmptyState'
 import TestButton from '@/test/TestButton'
 import TestInput from '@/test/TestInput'
 import TestModal from '@/test/TestModal'
+import TestRecoverAccountModal from '@/test/TestRecoverAccountModal'
 
 function TestPage() {
   return (
     <div>
       <h1>테스트 페이지입니다 UI 확인용</h1>
+
       <div className="flex justify-center">
         <Loading />
       </div>
+
       <Dropdown />
       <Toast />
       <TestButton />
       <TestInput />
       <TestModal />
+      <TestRecoverAccountModal />
+
       <div className="flex min-h-90 items-center justify-center">
         <ExamEmptyState />
       </div>

--- a/src/test/TestRecoverAccountModal.tsx
+++ b/src/test/TestRecoverAccountModal.tsx
@@ -1,0 +1,27 @@
+import { useState } from 'react'
+
+import RecoverAccountModal from '@/features/auth/login/RecoverAccountModal'
+
+const TestRecoverAccountModal = () => {
+  const [isRecoverAccountModalOpen, setIsRecoverAccountModalOpen] =
+    useState(false)
+
+  return (
+    <div className="flex gap-4">
+      <button
+        type="button"
+        onClick={() => setIsRecoverAccountModalOpen(true)}
+        className="rounded border p-2"
+      >
+        회원탈퇴 복구 모달
+      </button>
+
+      <RecoverAccountModal
+        isOpen={isRecoverAccountModalOpen}
+        onClose={() => setIsRecoverAccountModalOpen(false)}
+      />
+    </div>
+  )
+}
+
+export default TestRecoverAccountModal


### PR DESCRIPTION
📌 작업 내용
-탈퇴 회원 복구 모달 UI 구현
-이메일 인증 기반 계정 복구 플로우 구현
-인증 코드 입력 및 검증 UI 추가
-인증 타이머(5분) 기능 구현
-인증 완료 후 계정 복구 완료 팝업 구현 (공통 Popup 컴포넌트 활용)

**로그인 페이지 수정**
-LoginPage에서 복구 모달 테스트 연결 제거
-추후 로그인 API 연동 시 탈퇴 계정 응답일 때만 모달이 열리도록 TODO 처리

**검증 로직 추가**
-인증 코드 전송 전 이메일 입력 여부 검증
-인증 타이머 만료 시 인증 불가 처리
-인증 코드 검증 실패 / 성공 메시지 분리

**인증 입력 UI 공통 컴포넌트 분리**
-CodeVerification 컴포넌트 신규 생성
-이메일/휴대폰 input + 인증코드 input + 타이머 + 에러/성공 메시지 포함
-아이디 찾기, 비밀번호 찾기 등 다른 인증 모달에서도 재사용 가능하도록 설계

**기타 수정**
-Modal 스크롤 제어 훅(useModalScroll) 동작 보완
-테스트용 RecoverAccountModal 테스트 컴포넌트 추가
-RecoverAccountModal 아이콘 추가
-공통 Modal 컴포넌트 오버레이 색상 피그마 기준으로 수정
(bg-ui-gray-primary/60)

📎 참고사항
-인증코드는 임시 mock 값(123456) 사용 중이며, API 연동 시 서버 검증으로 교체 예정
-LoginPage에서 모달 직접 호출은 제거했으며, 추후 로그인 API에서 탈퇴 계정 응답 시 setIsRecoverModalOpen(true)로 연결 예정
-인증 UI는 아이디 찾기, 비밀번호 찾기 등 다른 인증 플로우에서도 재사용 가능하도록 공통 컴포넌트로 분리
-인증 상태, 검증 로직, 타이머 로직을 모달 UI와 분리하여 가독성과 유지보수성을 개선

** 동작 흐름**
1. 탈퇴 계정 상태에서 "계정 다시 사용하기" 클릭
2. 이메일 입력 후 인증코드 전송
3. 인증코드 입력 및 검증
4. 확인 버튼 클릭 시 계정 복구 완료 팝업 노출
5. 2초 후 로그인 페이지로 자동 이동

** 확인한 사항**
-모달 오픈/클로즈 시 인증 상태 초기화 확인
-인증코드 재전송 시 타이머 5분으로 초기화 확인
-인증 성공 시 성공 메시지 노출 확인
-인증 실패 / 만료 시 에러 메시지 노출 확인
-계정 복구 완료 팝업 노출 후 로그인 페이지 자동 이동 확인
-pnpm lint / pnpm tsc --noEmit 실행 확인

**변경 파일**
-src/features/auth/login/RecoverAccountModal.tsx
-src/components/common/CodeVerification.tsx
-src/hooks/useRecoverAccountVerification.ts
-src/hooks/useTimer.ts


## 🔗 관련 이슈

- closes #49 

## 📸 스크린샷 (선택)
<img width="908" height="803" alt="스크린샷 2026-03-14 오후 9 40 17" src="https://github.com/user-attachments/assets/6e31f15a-007c-41ef-a6c9-e5cbba5f0935" />

<img width="595" height="616" alt="스크린샷 2026-03-14 오후 9 40 57" src="https://github.com/user-attachments/assets/c3ddb9c6-c361-4a6a-9678-2445c962a45c" />

<img width="603" height="321" alt="스크린샷 2026-03-14 오후 10 53 49" src="https://github.com/user-attachments/assets/e9098c1d-b0aa-4462-8dc7-48bde888ca4c" />

수정 후

<img width="594" height="713" alt="스크린샷 2026-03-16 오후 7 11 55" src="https://github.com/user-attachments/assets/b4b73836-9f42-41d5-9700-f7d99d973429" />


<img width="750" height="301" alt="스크린샷 2026-03-16 오후 7 12 24" src="https://github.com/user-attachments/assets/2fd05d88-cebc-4742-ad42-1788c599abe1" />


## ✅ 체크리스트

- [ ] 코드 컨벤션 확인
- [ ] lint 에러 없음
- [ ] 빌드 정상 확인