### PR TITLE
feat: 회원 탈퇴 모달 및 탈퇴 사유 선택 UI 구현

### DIFF
--- a/src/api/mypage.ts
+++ b/src/api/mypage.ts
@@ -1,4 +1,5 @@
 import type {
+  DeleteMyAccountRequest,
   EnrolledCourseResponse,
   MyInfoResponse,
   UpdateMyInfoRequest,
@@ -13,7 +14,7 @@ export const getMyInfo = async () => {
 
 export const patchMyInfo = async (payload: UpdateMyInfoRequest) => {
   const { data } = await api.patch<MyInfoResponse>(
-    APIS_PATHS.PATCH_MY_Info,
+    APIS_PATHS.PATCH_MY_INFO,
     payload
   )
   return data
@@ -24,4 +25,12 @@ export const getMyEnrolledCourses = async () => {
     APIS_PATHS.GET_MY_ENROLLED_COURSES
   )
   return data
+}
+
+export const deleteMyAccount = async (payload: DeleteMyAccountRequest) => {
+  const response = await api.delete(APIS_PATHS.DELETE_MY_ACCOUNT, {
+    data: payload,
+  })
+
+  return response.data
 }

--- a/src/api/queries/useDeleteMyAccount.ts
+++ b/src/api/queries/useDeleteMyAccount.ts
@@ -1,0 +1,10 @@
+import { useMutation } from '@tanstack/react-query'
+
+import { deleteMyAccount } from '@/api/mypage'
+import type { DeleteMyAccountRequest } from '@/types'
+
+export const useDeleteMyAccount = () => {
+  return useMutation({
+    mutationFn: (payload: DeleteMyAccountRequest) => deleteMyAccount(payload),
+  })
+}

--- a/src/constants/apisPaths.ts
+++ b/src/constants/apisPaths.ts
@@ -3,7 +3,8 @@
  */
 export const APIS_PATHS = {
   GET_MY_INFO: '/accounts/me',
-  PATCH_MY_Info: '/accounts/me',
+  PATCH_MY_INFO: '/accounts/me',
+  DELETE_MY_ACCOUNT: '/accounts/me',
   GET_MY_ENROLLED_COURSES: '/accounts/me/enrolled-courses',
   AVAILABLE_COURSES: '/accounts/available-courses',
 }

--- a/src/constants/deleteUserReasonOptions.ts
+++ b/src/constants/deleteUserReasonOptions.ts
@@ -1,0 +1,13 @@
+import type { DeleteUserReason } from '@/types'
+
+export const DELETE_REASON_OPTIONS: {
+  value: DeleteUserReason
+  label: string
+}[] = [
+  { value: 'GRADUATION', label: '원하는 종류의 강의가 없어서' },
+  { value: 'TRANSFER', label: '타 부트캠프에 더 양질의 컨텐츠가 있어서' },
+  { value: 'SERVICE_DISSATISFACTION', label: '사이트 UI/UX가 불편해서' },
+  { value: 'NO_LONGER_NEEDED', label: '부트캠프를 수강완료해서' },
+  { value: 'PRIVACY_CONCERN', label: '개인정보/보안이 우려돼서' },
+  { value: 'OTHER', label: '기타(직접입력)' },
+]

--- a/src/features/mypage/MyInfoView.tsx
+++ b/src/features/mypage/MyInfoView.tsx
@@ -1,7 +1,15 @@
 import Button from '@/components/ui/button'
-import type { EnrolledCourseResponse, MyInfoResponse } from '@/types'
+import type {
+  DeleteMyAccountRequest,
+  EnrolledCourseResponse,
+  MyInfoResponse,
+} from '@/types'
 import profileViewIcon from '../../assets/icons/profileViewIcon.svg'
 import EnrolledCourseCard from './EnrolledCourseCard'
+import DeleteUserAccountModal from './delete-user/DeleteUserAccountModal'
+import { useState } from 'react'
+import { useDeleteMyAccount } from '@/api/queries/useDeleteMyAccount'
+import { toast } from 'sonner'
 
 type MyInfoViewProps = {
   myInfo: MyInfoResponse
@@ -19,135 +27,172 @@ export default function MyInfoView({
   enrolledCourses,
   onEdit,
 }: MyInfoViewProps) {
+  const [isWithdrawModalOpen, setIsWithdrawModalOpen] = useState(false)
+
+  const { mutate: deleteMyAccountMutate, isPending } = useDeleteMyAccount()
+
+  const handleWithdrawSubmit = (payload: DeleteMyAccountRequest) => {
+    deleteMyAccountMutate(payload, {
+      onSuccess: () => {
+        toast.success('회원 탈퇴가 완료되었습니다.')
+
+        setIsWithdrawModalOpen(false)
+
+        /**
+         * TODO:
+         * - 로그아웃 처리
+         * - 토큰 제거
+         * - 메인/로그인 페이지 이동
+         * - 토스트 표시
+         */
+      },
+      onError: () => {
+        toast.error('회원 탈퇴에 실패했습니다.')
+      },
+    })
+  }
   return (
-    <section className="w-186">
-      <div className="mb-5 flex items-center justify-between">
-        <h1 className="text-gray-primary text-[32px] font-bold">내 정보</h1>
-        <Button
-          onClick={onEdit}
-          variant="fill"
-          size="md"
-          className="h-12 w-32 rounded-lg px-9 py-5 text-base font-semibold"
-        >
-          수정하기
-        </Button>
-      </div>
+    <>
+      <section className="w-186">
+        <div className="mb-5 flex items-center justify-between">
+          <h1 className="text-gray-primary text-[32px] font-bold">내 정보</h1>
+          <Button
+            onClick={onEdit}
+            variant="fill"
+            size="md"
+            className="h-12 w-32 rounded-lg px-9 py-5 text-base font-semibold"
+          >
+            수정하기
+          </Button>
+        </div>
 
-      <div className="space-y-6">
-        <section className="mb-5 rounded-xl border border-gray-200 bg-white px-11 py-13">
-          <h2 className="text-primary-400 mb-13 border-b border-gray-200 pb-4 text-xl font-bold">
-            프로필
-          </h2>
+        <div className="space-y-6">
+          <section className="mb-5 rounded-xl border border-gray-200 bg-white px-11 py-13">
+            <h2 className="text-primary-400 mb-13 border-b border-gray-200 pb-4 text-xl font-bold">
+              프로필
+            </h2>
 
-          <div className="flex flex-col items-center">
-            <div className="mb-13 h-46 w-46 overflow-hidden rounded-full bg-violet-100">
-              {myInfo.profile_img_url ? (
-                <img
-                  src={myInfo.profile_img_url}
-                  alt="프로필 이미지"
-                  className="h-full w-full object-cover"
-                />
-              ) : (
-                <div>
+            <div className="flex flex-col items-center">
+              <div className="mb-13 h-46 w-46 overflow-hidden rounded-full bg-violet-100">
+                {myInfo.profile_img_url ? (
                   <img
-                    src={profileViewIcon}
+                    src={myInfo.profile_img_url}
                     alt="프로필 이미지"
-                    className="h-full w-full"
+                    className="h-full w-full object-cover"
                   />
+                ) : (
+                  <div>
+                    <img
+                      src={profileViewIcon}
+                      alt="프로필 이미지"
+                      className="h-full w-full"
+                    />
+                  </div>
+                )}
+              </div>
+
+              <div className="w-full space-y-10">
+                <div className="grid grid-cols-[200px_1fr] items-center gap-y-10">
+                  <p className="text-gray-primary text-lg">닉네임</p>
+                  <p className="text-gray-primary text-base">
+                    {myInfo.nickname}
+                  </p>
                 </div>
+
+                <div className="grid grid-cols-[200px_1fr] items-center gap-y-10">
+                  <p className="text-gray-primary text-lg">이메일</p>
+                  <p className="text-gray-primary text-base">{myInfo.email}</p>
+                </div>
+              </div>
+            </div>
+
+            <div className="mt-25">
+              <h3 className="text-primary-400 mb-13 border-b border-gray-200 pb-4 text-xl font-bold">
+                개인 정보
+              </h3>
+
+              <div className="space-y-5">
+                <div className="grid grid-cols-[200px_1fr] items-center">
+                  <p className="text-gray-primary text-lg">이름</p>
+                  <p className="text-gray-primary text-base">{myInfo.name}</p>
+                </div>
+
+                <div className="grid grid-cols-[200px_1fr] items-center">
+                  <p className="text-gray-primary text-lg">휴대전화</p>
+                  <p className="text-gray-primary text-base">
+                    {myInfo.phone_number}
+                  </p>
+                </div>
+
+                <div className="grid grid-cols-[200px_1fr] items-center">
+                  <p className="text-gray-primary text-lg">성별</p>
+                  <p className="text-gray-primary text-base">
+                    {genderLabelMap[myInfo.gender]}
+                  </p>
+                </div>
+
+                <div className="grid grid-cols-[200px_1fr] items-center">
+                  <p className="text-gray-primary text-lg">생년월일</p>
+                  <p className="text-gray-primary text-base">
+                    {myInfo.birthday}
+                  </p>
+                </div>
+              </div>
+            </div>
+          </section>
+
+          <section className="mb-13 rounded-lg border border-gray-200 bg-white px-11 py-13">
+            <h2 className="text-primary-400 mb-10 border-b border-gray-200 pb-4 text-xl font-bold">
+              수강 중인 과정
+            </h2>
+
+            <div>
+              {enrolledCourses.length > 0 ? (
+                enrolledCourses.map((course, index) => (
+                  <EnrolledCourseCard
+                    key={`${course.course.id}-${course.cohort.id}-${index}`}
+                    course={course}
+                  />
+                ))
+              ) : (
+                <p className="text-xl text-gray-400">
+                  수강 중인 과정이 없습니다.
+                </p>
               )}
             </div>
+          </section>
 
-            <div className="w-full space-y-10">
-              <div className="grid grid-cols-[200px_1fr] items-center gap-y-10">
-                <p className="text-gray-primary text-lg">닉네임</p>
-                <p className="text-gray-primary text-base">{myInfo.nickname}</p>
-              </div>
-
-              <div className="grid grid-cols-[200px_1fr] items-center gap-y-10">
-                <p className="text-gray-primary text-lg">이메일</p>
-                <p className="text-gray-primary text-base">{myInfo.email}</p>
-              </div>
-            </div>
-          </div>
-
-          <div className="mt-25">
-            <h3 className="text-primary-400 mb-13 border-b border-gray-200 pb-4 text-xl font-bold">
-              개인 정보
-            </h3>
-
-            <div className="space-y-5">
-              <div className="grid grid-cols-[200px_1fr] items-center">
-                <p className="text-gray-primary text-lg">이름</p>
-                <p className="text-gray-primary text-base">{myInfo.name}</p>
-              </div>
-
-              <div className="grid grid-cols-[200px_1fr] items-center">
-                <p className="text-gray-primary text-lg">휴대전화</p>
-                <p className="text-gray-primary text-base">
-                  {myInfo.phone_number}
-                </p>
-              </div>
-
-              <div className="grid grid-cols-[200px_1fr] items-center">
-                <p className="text-gray-primary text-lg">성별</p>
-                <p className="text-gray-primary text-base">
-                  {genderLabelMap[myInfo.gender]}
-                </p>
-              </div>
-
-              <div className="grid grid-cols-[200px_1fr] items-center">
-                <p className="text-gray-primary text-lg">생년월일</p>
-                <p className="text-gray-primary text-base">{myInfo.birthday}</p>
-              </div>
-            </div>
-          </div>
-        </section>
-
-        <section className="mb-13 rounded-lg border border-gray-200 bg-white px-11 py-13">
-          <h2 className="text-primary-400 mb-10 border-b border-gray-200 pb-4 text-xl font-bold">
-            수강 중인 과정
-          </h2>
-
-          <div>
-            {enrolledCourses.length > 0 ? (
-              enrolledCourses.map((course, index) => (
-                <EnrolledCourseCard
-                  key={`${course.course.id}-${course.cohort.id}-${index}`}
-                  course={course}
-                />
-              ))
-            ) : (
-              <p className="text-xl text-gray-400">
-                수강 중인 과정이 없습니다.
+          <section className="mb-35 flex items-end justify-between rounded-lg border border-transparent py-12">
+            <div>
+              <p className="text-ui-gray-400 mb-8 text-xl font-medium">
+                회원 탈퇴 안내
               </p>
-            )}
-          </div>
-        </section>
+              <p className="text-ui-gray-disabled text-sm font-medium">
+                탈퇴 처리 시, 수강 기록 / 포인트 / 쿠폰은 소멸되며 복구되지
+                않습니다.
+                <br />
+                필요한 경우, 탈퇴 신청 전 문의해 주세요.
+              </p>
+            </div>
 
-        <section className="mb-35 flex items-end justify-between rounded-lg border border-transparent py-12">
-          <div>
-            <p className="text-ui-gray-400 mb-8 text-xl font-medium">
-              회원 탈퇴 안내
-            </p>
-            <p className="text-ui-gray-disabled text-sm font-medium">
-              탈퇴 처리 시, 수강 기록 / 포인트 / 쿠폰은 소멸되며 복구되지
-              않습니다.
-              <br />
-              필요한 경우, 탈퇴 신청 전 문의해 주세요.
-            </p>
-          </div>
-
-          <Button
-            type="button"
-            variant="ghost"
-            size="md"
-            className="bg-ui-gray-200 text-ui-gray-600 rounded-lg px-7 py-4 text-base font-semibold"
-          >
-            회원 탈퇴하기
-          </Button>
-        </section>
-      </div>
-    </section>
+            <Button
+              type="button"
+              onClick={() => setIsWithdrawModalOpen(true)}
+              variant="ghost"
+              size="md"
+              className="bg-ui-gray-200 text-ui-gray-600 rounded-lg px-7 py-4 text-base font-semibold"
+            >
+              회원 탈퇴하기
+            </Button>
+          </section>
+        </div>
+      </section>
+      <DeleteUserAccountModal
+        isOpen={isWithdrawModalOpen}
+        onClose={() => setIsWithdrawModalOpen(false)}
+        onSubmit={handleWithdrawSubmit}
+        isPending={isPending}
+      />
+    </>
   )
 }

--- a/src/features/mypage/delete-user/DeleteReasonDropdown.tsx
+++ b/src/features/mypage/delete-user/DeleteReasonDropdown.tsx
@@ -1,0 +1,79 @@
+import { useState } from 'react'
+
+import CheckIcon from '@/assets/icons/check.svg?react'
+import {
+  DropdownButton,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuGroup,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu'
+import { DELETE_REASON_OPTIONS } from '@/constants/deleteUserReasonOptions'
+import { cn } from '@/lib/utils'
+import type { DeleteUserReason } from '@/types'
+
+type DeleteReasonDropdownProps = {
+  value: DeleteUserReason | null
+  onChange: (reason: DeleteUserReason) => void
+}
+
+/**
+ * 회원 탈퇴 드롭다운
+ */
+export default function DeleteReasonDropdown({
+  value,
+  onChange,
+}: DeleteReasonDropdownProps) {
+  const [isOpen, setIsOpen] = useState(false)
+  const selectedOption = DELETE_REASON_OPTIONS.find(
+    (option) => option.value === value
+  )
+
+  const handleSelect = (reason: DeleteUserReason) => {
+    onChange(reason)
+    setIsOpen(false)
+  }
+
+  return (
+    <DropdownMenu open={isOpen} onOpenChange={setIsOpen}>
+      <DropdownMenuTrigger asChild>
+        <div>
+          <DropdownButton
+            isOpen={isOpen}
+            value={selectedOption?.label}
+            placeholder="해당되는 항목을 선택해 주세요."
+            className="mb-0 h-12 w-72 cursor-pointer rounded-lg px-4 py-2.5"
+          />
+        </div>
+      </DropdownMenuTrigger>
+
+      <DropdownMenuContent
+        align="start"
+        className="z-1100 w-72 rounded-lg py-1.25 text-sm"
+      >
+        <DropdownMenuGroup>
+          {DELETE_REASON_OPTIONS.map((option) => {
+            const isSelected = value === option.value
+
+            return (
+              <DropdownMenuItem
+                key={option.value}
+                onClick={() => handleSelect(option.value)}
+                className={cn(
+                  'text-ui-gray-primary flex h-12 w-full cursor-pointer items-center justify-between px-4 text-sm',
+                  isSelected && 'text-primary-default font-semibold'
+                )}
+              >
+                <span>{option.label}</span>
+                {isSelected && (
+                  <CheckIcon className="text-primary-default h-4 w-4 shrink-0" />
+                )}
+              </DropdownMenuItem>
+            )
+          })}
+        </DropdownMenuGroup>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  )
+}

--- a/src/features/mypage/delete-user/DeleteUserAccountModal.tsx
+++ b/src/features/mypage/delete-user/DeleteUserAccountModal.tsx
@@ -1,0 +1,108 @@
+import { useEffect, useState } from 'react'
+
+import Button from '@/components/ui/button'
+import Modal from '@/components/ui/modal/Modal'
+import type { DeleteMyAccountRequest, DeleteUserReason } from '@/types'
+import Textarea from '@/components/ui/textarea'
+import DeleteReasonDropdown from './DeleteReasonDropdown'
+
+type DeleteUserAccountModalProps = {
+  isOpen: boolean
+  onClose: () => void
+  onSubmit: (payload: DeleteMyAccountRequest) => void
+  isPending?: boolean
+}
+
+/**
+ * 회원 탈퇴 모달
+ */
+export default function DeleteUserAccountModal({
+  isOpen,
+  onClose,
+  onSubmit,
+  isPending = false,
+}: DeleteUserAccountModalProps) {
+  const [selectedReason, setSelectedReason] = useState<DeleteUserReason | null>(
+    null
+  )
+  const [reasonDetail, setReasonDetail] = useState('')
+
+  useEffect(() => {
+    if (!isOpen) {
+      setSelectedReason(null)
+      setReasonDetail('')
+    }
+  }, [isOpen])
+
+  const isReasonSelected = Boolean(selectedReason)
+  const isSubmitDisabled = !isReasonSelected || isPending
+
+  const handleSubmit = () => {
+    if (!selectedReason) {
+      return
+    }
+
+    onSubmit({
+      reason: selectedReason,
+      reason_detail: reasonDetail.trim(),
+    })
+  }
+
+  return (
+    <Modal isOpen={isOpen} onClose={onClose}>
+      <div className="w-161.5 rounded-2xl bg-white p-6">
+        <div className="text-ui-gray-primary mb-10 text-xl font-bold">
+          오즈코딩스쿨을 탈퇴하시는 이유는 무엇인가요?
+        </div>
+
+        <p className="text-ui-gray-disabled mb-8 text-base font-normal">
+          계정을 삭제하시면 회원님의 모든 콘텐츠와 활동 기록, 수강 기간 / 포인트
+          / 쿠폰 내역이 사라지며 환불되지 않습니다. 삭제된 정보는 복구할 수
+          없습니다.
+        </p>
+
+        <div className="mb-10">
+          <DeleteReasonDropdown
+            value={selectedReason}
+            onChange={setSelectedReason}
+          />
+        </div>
+
+        <div className="mb-10">
+          <p className="text-ui-gray-primary mb-4 text-base font-normal">
+            서비스를 이용하시면서 불편했던 점이나 보완할 수 있는 방안을
+            알려주시면, 서비스 개선에 적극적으로 반영하겠습니다. 감사합니다!
+          </p>
+
+          <Textarea
+            value={reasonDetail}
+            onChange={(e) => setReasonDetail(e.target.value)}
+            placeholder={
+              isReasonSelected
+                ? '소중한 의견을 반영해 더 좋은 서비스를 위해 노력하겠습니다.'
+                : '탈퇴 사유를 먼저 선택해 주세요.'
+            }
+            variant="feedback"
+            size="md"
+            className="w-full disabled:cursor-not-allowed"
+            maxLength={200}
+            disabled={!isReasonSelected}
+          />
+        </div>
+
+        <div className="mb-4 flex justify-center">
+          <Button
+            type="button"
+            onClick={handleSubmit}
+            disabled={isSubmitDisabled}
+            variant="outline"
+            size="md"
+            className="disabled:cursor-not-allowed"
+          >
+            회원 탈퇴하기
+          </Button>
+        </div>
+      </div>
+    </Modal>
+  )
+}

--- a/src/mocks/handlers/myPageHandlers.ts
+++ b/src/mocks/handlers/myPageHandlers.ts
@@ -50,4 +50,59 @@ export const mypageHandlers = [
   http.get('/api/v1/accounts/me/enrolled-courses', async () => {
     return HttpResponse.json(enrolledCoursesMock, { status: 200 })
   }),
+
+  /**
+   * 회원 탈퇴
+   */
+  http.delete('/api/v1/accounts/me', async ({ request }) => {
+    /**
+     * TODO: authHeader 수정 예정
+     */
+    // const authHeader = request.headers.get('Authorization')
+
+    // if (!authHeader) {
+    //   return HttpResponse.json(
+    //     {
+    //       error_detail: '자격 인증 데이터가 제공되지 않았습니다.',
+    //     },
+    //     { status: 401 }
+    //   )
+    // }
+
+    const body = (await request.json()) as {
+      reason?: string
+      reason_detail?: string
+    }
+
+    const validReasons = [
+      'GRADUATION',
+      'TRANSFER',
+      'NO_LONGER_NEEDED',
+      'SERVICE_DISSATISFACTION',
+      'PRIVACY_CONCERN',
+      'OTHER',
+    ]
+
+    if (!body?.reason) {
+      return HttpResponse.json(
+        {
+          error_detail: 'reason은 필수입니다.',
+        },
+        { status: 400 }
+      )
+    }
+
+    if (!validReasons.includes(body.reason)) {
+      return HttpResponse.json(
+        {
+          error_detail: '유효하지 않은 탈퇴 사유입니다.',
+        },
+        { status: 400 }
+      )
+    }
+
+    return new HttpResponse(null, {
+      status: 204,
+    })
+  }),
 ]

--- a/src/types/api-request/myPageRequest.ts
+++ b/src/types/api-request/myPageRequest.ts
@@ -6,3 +6,16 @@ export type UpdateMyInfoRequest = {
   birthday?: string
   gender?: Gender
 }
+
+export type DeleteUserReason =
+  | 'GRADUATION'
+  | 'TRANSFER'
+  | 'NO_LONGER_NEEDED'
+  | 'SERVICE_DISSATISFACTION'
+  | 'PRIVACY_CONCERN'
+  | 'OTHER'
+
+export type DeleteMyAccountRequest = {
+  reason: DeleteUserReason
+  reason_detail: string
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -8,4 +8,8 @@ export type {
   EnrolledCourseStatus,
   EnrolledCourseResponse,
 } from './api-response/myPageResponse'
-export type { UpdateMyInfoRequest } from './api-request/myPageRequest'
+export type {
+  UpdateMyInfoRequest,
+  DeleteMyAccountRequest,
+  DeleteUserReason,
+} from './api-request/myPageRequest'


### PR DESCRIPTION
## 📌 작업 내용

회원 탈퇴 API 및 MSW 목 핸들러 추가
- 회원 탈퇴 요청 타입과 사유 타입 정의
- 회원 탈퇴 API 함수와 Tanstack Query mutation 훅 추가
- 마이페이지 API 경로 상수 정리 및 삭제 엔드포인트 추가
- MSW 마이페이지 핸들러에 회원 탈퇴 검증 로직 구현

회원 탈퇴 모달 및 탈퇴 사유 선택 UI 구현
- 회원 탈퇴 사유 옵션 상수 추가
- 탈퇴 사유 선택 드롭다운과 회원 탈퇴 모달 UI 구현
- 마이페이지 내 정보 화면에 회원 탈퇴 모달 연동

## 🔗 관련 이슈

- closes #59 

## 📸 스크린샷 (선택)
<img width="673" height="691" alt="스크린샷 2026-03-16 오후 6 24 17" src="https://github.com/user-attachments/assets/853b9643-98b0-48c5-b814-2c92964584d1" />

<img width="673" height="691" alt="스크린샷 2026-03-16 오후 6 24 34" src="https://github.com/user-attachments/assets/e90e8256-e477-41f8-857e-818d1a3f6211" />

## ✅ 체크리스트

- [ ] 코드 컨벤션 확인
- [ ] lint 에러 없음
- [ ] 빌드 정상 확인
