### PR TITLE
feat: 드래그앤드롭 구현 

### DIFF
--- a/src/features/quiz/OrderingQuestion.tsx
+++ b/src/features/quiz/OrderingQuestion.tsx
@@ -1,30 +1,74 @@
+import useOrderingDragAndDrop from '@/hooks/useOrderingDragAndDrop'
+
 type OrderingQuestionProps = {
   options: string[]
 }
 
 function OrderingQuestion({ options }: OrderingQuestionProps) {
-  const labels = ['A', 'B', 'C', 'D']
+  const {
+    availableItems,
+    answerSlots,
+    isItemUsed,
+    handleAvailableDragStart,
+    handleSlotDragStart,
+    handleDragOver,
+    handleSlotDrop,
+    handleRemoveSlotItem,
+  } = useOrderingDragAndDrop(options)
 
   return (
     <div>
       <div className="my-5 w-162 rounded-[4px] bg-gray-100 px-4 py-5">
         <ul className="flex flex-col gap-5">
-          {options.map((option, index) => (
-            <li key={index} className="flex items-center gap-4">
-              <div className="bg-primary-100 text-primary-default flex h-8 w-8 items-center justify-center rounded-[4px] text-center text-[18px] leading-[140%] font-normal tracking-[-0.03em]">
-                {labels[index]}
-              </div>
-              <span className="text-ui-gray-primary text-[16px] leading-[140%] font-normal tracking-[-0.03em]">
-                {option}
-              </span>
-            </li>
-          ))}
+          {availableItems.map((item, index) => {
+            const isUsed = isItemUsed(item)
+
+            return (
+              <li
+                key={item.label}
+                draggable={!isUsed}
+                onDragStart={() => {
+                  handleAvailableDragStart(index)
+                }}
+                className={`flex items-center gap-4 ${
+                  isUsed ? 'cursor-not-allowed opacity-50' : 'cursor-grab'
+                }`}
+              >
+                <div className="bg-primary-100 text-primary-default flex h-8 w-8 items-center justify-center rounded-[4px] text-center text-[18px] leading-[140%] font-normal tracking-[-0.03em]">
+                  {item.label}
+                </div>
+                <span className="text-ui-gray-primary text-[16px] leading-[140%] font-normal tracking-[-0.03em]">
+                  {item.text}
+                </span>
+              </li>
+            )
+          })}
         </ul>
       </div>
 
       <div className="flex gap-2.5">
-        {options.map((_, index) => (
-          <div key={index} className="h-15 w-15 rounded-[4px] bg-gray-100" />
+        {answerSlots.map((slot, index) => (
+          <div
+            key={index}
+            draggable={slot !== null}
+            onDragStart={() => {
+              handleSlotDragStart(index)
+            }}
+            onDragOver={handleDragOver}
+            onDrop={() => {
+              handleSlotDrop(index)
+            }}
+            onClick={() => {
+              handleRemoveSlotItem(index)
+            }}
+            className={`flex h-15 w-15 items-center justify-center rounded-[4px] transition ${
+              slot
+                ? 'bg-primary-100 text-primary-default hover:bg-primary-200 cursor-pointer text-2xl font-semibold'
+                : 'text-ui-gray-primary bg-gray-100'
+            }`}
+          >
+            {slot && <span>{slot.label}</span>}
+          </div>
         ))}
       </div>
     </div>

--- a/src/hooks/useOrderingDragAndDrop.ts
+++ b/src/hooks/useOrderingDragAndDrop.ts
@@ -1,0 +1,127 @@
+import { useState, type DragEvent } from 'react'
+
+type OrderingItem = {
+  label: string
+  text: string
+}
+// 드래그한 아이템의 위치 정보
+type DragItemInfo = {
+  source: 'available' | 'slot' // 위 보기 또는 아래 슬롯
+  index: number
+}
+
+const LABELS = ['A', 'B', 'C', 'D'] as const
+
+function useOrderingDragAndDrop(options: string[]) {
+  const [draggedItemInfo, setDraggedItemInfo] = useState<DragItemInfo | null>(
+    null
+  )
+  // 상단 보기 목록 data 호출
+  const availableItems: OrderingItem[] = options.map((option, index) => ({
+    label: LABELS[index],
+    text: option,
+  }))
+  // 정답 슬롯 state
+  const [answerSlots, setAnswerSlots] = useState<(OrderingItem | null)[]>(
+    new Array(options.length).fill(null)
+  )
+
+  // 해당 보기가 이미 아래 슬롯에 들어가 있는지 확인
+  const isItemUsed = (item: OrderingItem) => {
+    return answerSlots.some((slot) => {
+      return slot?.label === item.label
+    })
+  }
+
+  // 상단 보기에서 드래그 시작
+  const handleAvailableDragStart = (index: number) => {
+    const item = availableItems[index]
+
+    if (!item) {
+      return
+    }
+    if (isItemUsed(item)) {
+      return
+    }
+
+    setDraggedItemInfo({
+      source: 'available',
+      index,
+    })
+  }
+
+  // 하단 슬롯에서 드래그 시작
+  const handleSlotDragStart = (index: number) => {
+    if (answerSlots[index] === null) {
+      return
+    }
+    setDraggedItemInfo({
+      source: 'slot',
+      index,
+    })
+  }
+
+  // drop 가능하도록 기본 동작 막기
+  const handleDragOver = (event: DragEvent<HTMLDivElement>) => {
+    event.preventDefault()
+  }
+
+  // 특정 슬롯에 drop 했을 때 처리
+  const handleSlotDrop = (index: number) => {
+    if (draggedItemInfo === null) {
+      return
+    }
+    // 상단 보기 → 하단 슬롯으로 이동
+    if (draggedItemInfo.source === 'available') {
+      if (answerSlots[index] !== null) {
+        return
+      }
+
+      const draggedItem = availableItems[draggedItemInfo.index]
+
+      if (!draggedItem) {
+        return
+      }
+
+      const copiedSlots = [...answerSlots]
+      copiedSlots[index] = draggedItem
+      setAnswerSlots(copiedSlots)
+      setDraggedItemInfo(null)
+      return
+    }
+    // 하단 <-> 하단 슬롯 순서 교체
+    if (draggedItemInfo.source === 'slot') {
+      if (draggedItemInfo.index === index) {
+        return
+      }
+
+      const copiedSlots = [...answerSlots]
+      const temp = copiedSlots[index]
+      copiedSlots[index] = copiedSlots[draggedItemInfo.index]
+      copiedSlots[draggedItemInfo.index] = temp
+      setAnswerSlots(copiedSlots)
+      setDraggedItemInfo(null)
+    }
+  }
+  // 슬롯 제거
+  const handleRemoveSlotItem = (targetIndex: number) => {
+    setAnswerSlots((prev) => {
+      const next = [...prev]
+      next[targetIndex] = null
+      return next
+    })
+  }
+
+  return {
+    availableItems,
+    answerSlots,
+    isItemUsed,
+    handleRemoveSlotItem,
+    handleAvailableDragStart,
+    handleSlotDragStart,
+    handleDragOver,
+    handleSlotDrop,
+  }
+}
+
+export default useOrderingDragAndDrop


### PR DESCRIPTION
## 📌 작업 내용

- 순서배열 문제 드래그앤드롭 기능 구현
- 상단 보기를 하단 슬롯으로 이동할 수 있도록 처리
- 하단 슬롯에 배치된 답안의 순서를 드래그로 변경할 수 있도록 구현
- 배치된 답안을 클릭하면 제거할 수 있도록 처리
- 사용 여부에 따른 보기/슬롯 UI 상태 반영

## 🔗 관련 이슈

- closes #56 

## 📸 스크린샷 (선택)
<img width="844" height="420" alt="image" src="https://github.com/user-attachments/assets/f9a3ad2a-2ecb-407e-a963-04ab22c4f090" />

## ✅ 체크리스트

- [ ] 코드 컨벤션 확인
- [ ] lint 에러 없음
- [ ] 빌드 정상 확인
