### PR TITLE
feat: 비밀번호 변경 UI 및 클라이언트 검증 로직 구현

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,11 +31,13 @@
     "radix-ui": "^1.4.3",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
+    "react-hook-form": "^7.71.2",
     "react-router": "^7.6.2",
     "react-router-dom": "^7.13.1",
     "sonner": "^2.0.7",
     "tailwind-merge": "^3.5.0",
     "tailwindcss": "^4.1.10",
+    "zod": "^4.3.6",
     "zustand": "^5.0.5"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,6 +38,9 @@ importers:
       react-dom:
         specifier: ^19.1.0
         version: 19.2.4(react@19.2.4)
+      react-hook-form:
+        specifier: ^7.71.2
+        version: 7.71.2(react@19.2.4)
       react-router:
         specifier: ^7.6.2
         version: 7.13.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -53,6 +56,9 @@ importers:
       tailwindcss:
         specifier: ^4.1.10
         version: 4.2.1
+      zod:
+        specifier: ^4.3.6
+        version: 4.3.6
       zustand:
         specifier: ^5.0.5
         version: 5.0.11(@types/react@19.2.14)(react@19.2.4)(use-sync-external-store@1.6.0(react@19.2.4))
@@ -1427,79 +1433,66 @@ packages:
     resolution: {integrity: sha512-t4ONHboXi/3E0rT6OZl1pKbl2Vgxf9vJfWgmUoCEVQVxhW6Cw/c8I6hbbu7DAvgp82RKiH7TpLwxnJeKv2pbsw==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.59.0':
     resolution: {integrity: sha512-CikFT7aYPA2ufMD086cVORBYGHffBo4K8MQ4uPS/ZnY54GKj36i196u8U+aDVT2LX4eSMbyHtyOh7D7Zvk2VvA==}
     cpu: [arm]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.59.0':
     resolution: {integrity: sha512-jYgUGk5aLd1nUb1CtQ8E+t5JhLc9x5WdBKew9ZgAXg7DBk0ZHErLHdXM24rfX+bKrFe+Xp5YuJo54I5HFjGDAA==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.59.0':
     resolution: {integrity: sha512-peZRVEdnFWZ5Bh2KeumKG9ty7aCXzzEsHShOZEFiCQlDEepP1dpUl/SrUNXNg13UmZl+gzVDPsiCwnV1uI0RUA==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.59.0':
     resolution: {integrity: sha512-gbUSW/97f7+r4gHy3Jlup8zDG190AuodsWnNiXErp9mT90iCy9NKKU0Xwx5k8VlRAIV2uU9CsMnEFg/xXaOfXg==}
     cpu: [loong64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.59.0':
     resolution: {integrity: sha512-yTRONe79E+o0FWFijasoTjtzG9EBedFXJMl888NBEDCDV9I2wGbFFfJQQe63OijbFCUZqxpHz1GzpbtSFikJ4Q==}
     cpu: [loong64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.59.0':
     resolution: {integrity: sha512-sw1o3tfyk12k3OEpRddF68a1unZ5VCN7zoTNtSn2KndUE+ea3m3ROOKRCZxEpmT9nsGnogpFP9x6mnLTCaoLkA==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.59.0':
     resolution: {integrity: sha512-+2kLtQ4xT3AiIxkzFVFXfsmlZiG5FXYW7ZyIIvGA7Bdeuh9Z0aN4hVyXS/G1E9bTP/vqszNIN/pUKCk/BTHsKA==}
     cpu: [ppc64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.59.0':
     resolution: {integrity: sha512-NDYMpsXYJJaj+I7UdwIuHHNxXZ/b/N2hR15NyH3m2qAtb/hHPA4g4SuuvrdxetTdndfj9b1WOmy73kcPRoERUg==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.59.0':
     resolution: {integrity: sha512-nLckB8WOqHIf1bhymk+oHxvM9D3tyPndZH8i8+35p/1YiVoVswPid2yLzgX7ZJP0KQvnkhM4H6QZ5m0LzbyIAg==}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.59.0':
     resolution: {integrity: sha512-oF87Ie3uAIvORFBpwnCvUzdeYUqi2wY6jRFWJAy1qus/udHFYIkplYRW+wo+GRUP4sKzYdmE1Y3+rY5Gc4ZO+w==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.59.0':
     resolution: {integrity: sha512-3AHmtQq/ppNuUspKAlvA8HtLybkDflkMuLK4DPo77DfthRb71V84/c4MlWJXixZz4uruIH4uaa07IqoAkG64fg==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.59.0':
     resolution: {integrity: sha512-2UdiwS/9cTAx7qIUZB/fWtToJwvt0Vbo0zmnYt7ED35KPg13Q0ym1g442THLC7VyI6JfYTP4PiSOWyoMdV2/xg==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.59.0':
     resolution: {integrity: sha512-M3bLRAVk6GOwFlPTIxVBSYKUaqfLrn8l0psKinkCFxl4lQvOSz8ZrKDz2gxcBwHFpci0B6rttydI4IpS4IS/jQ==}
@@ -1648,28 +1641,24 @@ packages:
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.2.1':
     resolution: {integrity: sha512-WZA0CHRL/SP1TRbA5mp9htsppSEkWuQ4KsSUumYQnyl8ZdT39ntwqmz4IUHGN6p4XdSlYfJwM4rRzZLShHsGAQ==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.2.1':
     resolution: {integrity: sha512-qMFzxI2YlBOLW5PhblzuSWlWfwLHaneBE0xHzLrBgNtqN6mWfs+qYbhryGSXQjFYB1Dzf5w+LN5qbUTPhW7Y5g==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.2.1':
     resolution: {integrity: sha512-5r1X2FKnCMUPlXTWRYpHdPYUY6a1Ar/t7P24OuiEdEOmms5lyqjDRvVY1yy9Rmioh+AunQ0rWiOTPE8F9A3v5g==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.2.1':
     resolution: {integrity: sha512-MGFB5cVPvshR85MTJkEvqDUnuNoysrsRxd6vnk1Lf2tbiqNlXpHYZqkqOQalydienEWOHHFyyuTSYRsLfxFJ2Q==}
@@ -3012,28 +3001,24 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.31.1:
     resolution: {integrity: sha512-mVZ7Pg2zIbe3XlNbZJdjs86YViQFoJSpc41CbVmKBPiGmC4YrfeOyz65ms2qpAobVd7WQsbW4PdsSJEMymyIMg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.31.1:
     resolution: {integrity: sha512-xGlFWRMl+0KvUhgySdIaReQdB4FNudfUTARn7q0hh/V67PVGCs3ADFjw+6++kG1RNd0zdGRlEKa+T13/tQjPMA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.31.1:
     resolution: {integrity: sha512-eowF8PrKHw9LpoZii5tdZwnBcYDxRw2rRCyvAXLi34iyeYfqCQNA9rmUM0ce62NlPhCvof1+9ivRaTY6pSKDaA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.31.1:
     resolution: {integrity: sha512-aJReEbSEQzx1uBlQizAOBSjcmr9dCdL3XuC/6HLXAxmtErsj2ICo5yYggg1qOODQMtnjNQv2UHb9NpOuFtYe4w==}
@@ -3517,6 +3502,12 @@ packages:
     resolution: {integrity: sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==}
     peerDependencies:
       react: ^19.2.4
+
+  react-hook-form@7.71.2:
+    resolution: {integrity: sha512-1CHvcDYzuRUNOflt4MOq3ZM46AronNJtQ1S7tnX6YN4y72qhgiUItpacZUAQ0TyWYci3yz1X+rXaSxiuEm86PA==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      react: ^16.8.0 || ^17 || ^18 || ^19
 
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
@@ -4155,6 +4146,9 @@ packages:
 
   zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
+
+  zod@4.3.6:
+    resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
 
   zustand@5.0.11:
     resolution: {integrity: sha512-fdZY+dk7zn/vbWNCYmzZULHRrss0jx5pPFiOuMZ/5HJN6Yv3u+1Wswy/4MpZEkEGhtNH+pwxZB8OKgUBPzYAGg==}
@@ -7649,6 +7643,10 @@ snapshots:
       react: 19.2.4
       scheduler: 0.27.0
 
+  react-hook-form@7.71.2(react@19.2.4):
+    dependencies:
+      react: 19.2.4
+
   react-is@16.13.1: {}
 
   react-refresh@0.17.0: {}
@@ -8388,6 +8386,8 @@ snapshots:
       zod: 3.25.76
 
   zod@3.25.76: {}
+
+  zod@4.3.6: {}
 
   zustand@5.0.11(@types/react@19.2.14)(react@19.2.4)(use-sync-external-store@1.6.0(react@19.2.4)):
     optionalDependencies:

--- a/src/api/mypage.ts
+++ b/src/api/mypage.ts
@@ -6,6 +6,8 @@ import type {
 } from '@/types'
 import { api } from './api'
 import { APIS_PATHS } from '@/constants/apisPaths'
+import type { ChangePasswordRequest } from '@/types/api-request/myPageRequest'
+import type { ChangePasswordResponse } from '@/types/api-response/myPageResponse'
 
 export const getMyInfo = async () => {
   const { data } = await api.get<MyInfoResponse>(APIS_PATHS.GET_MY_INFO)
@@ -33,4 +35,15 @@ export const deleteMyAccount = async (payload: DeleteMyAccountRequest) => {
   })
 
   return response.data
+}
+
+export const postChangePassword = async (
+  payload: ChangePasswordRequest
+): Promise<ChangePasswordResponse> => {
+  const { data } = await api.post<ChangePasswordResponse>(
+    APIS_PATHS.CHANGE_PASSWORD,
+    payload
+  )
+
+  return data
 }

--- a/src/api/queries/useChangePassword.ts
+++ b/src/api/queries/useChangePassword.ts
@@ -1,0 +1,10 @@
+import { useMutation } from '@tanstack/react-query'
+import type { ChangePasswordResponse } from '@/types/api-response/myPageResponse'
+import type { ChangePasswordRequest } from '@/types/api-request/myPageRequest'
+import { postChangePassword } from '../mypage'
+
+export const useChangePassword = () => {
+  return useMutation<ChangePasswordResponse, Error, ChangePasswordRequest>({
+    mutationFn: postChangePassword,
+  })
+}

--- a/src/constants/apisPaths.ts
+++ b/src/constants/apisPaths.ts
@@ -7,4 +7,5 @@ export const APIS_PATHS = {
   DELETE_MY_ACCOUNT: '/accounts/me',
   GET_MY_ENROLLED_COURSES: '/accounts/me/enrolled-courses',
   AVAILABLE_COURSES: '/accounts/available-courses',
+  CHANGE_PASSWORD: '/accounts/change-password',
 }

--- a/src/constants/passwordChangeFields.ts
+++ b/src/constants/passwordChangeFields.ts
@@ -1,0 +1,29 @@
+import type { ChangePasswordFormValues } from '@/schemas/changePasswordSchema'
+
+type PasswordFieldConfig = {
+  id: string
+  label: string
+  name: keyof ChangePasswordFormValues
+  placeholder: string
+}
+
+export const PASSWORD_CHANGE_FIELDS: PasswordFieldConfig[] = [
+  {
+    id: 'old_password',
+    label: '기존 비밀번호',
+    name: 'old_password',
+    placeholder: '기존 비밀번호를 입력해주세요.',
+  },
+  {
+    id: 'new_password',
+    label: '새 비밀번호',
+    name: 'new_password',
+    placeholder: '새 비밀번호를 입력해주세요.',
+  },
+  {
+    id: 'confirmPassword',
+    label: '새 비밀번호 확인',
+    name: 'confirmPassword',
+    placeholder: '새 비밀번호를 한 번 더 입력해주세요.',
+  },
+]

--- a/src/features/mypage/MyPasswordTab.tsx
+++ b/src/features/mypage/MyPasswordTab.tsx
@@ -1,12 +1,152 @@
-export default function MyPasswordTab() {
-  return (
-    <section className="border-grey-3 bg-grey-1 w-186 rounded-lg px-6 py-6">
-      <h1 className="text-grey-6 mb-6 text-[32px] font-bold">비밀번호 변경</h1>
+import { useForm } from 'react-hook-form'
+import { useChangePassword } from '@/api/queries/useChangePassword'
+import {
+  changePasswordSchema,
+  type ChangePasswordFormValues,
+} from '@/schemas/changePasswordSchema'
+import axios from 'axios'
+import InputField from '@/components/common/InputField'
+import Button from '@/components/ui/button'
+import { toast } from 'sonner'
+import { changePasswordZodErrorsToRHF } from '@/utils/changePasswordZodErrorsToRHF'
+import { PASSWORD_CHANGE_FIELDS } from '@/constants/passwordChangeFields'
 
-      <div className="border-grey-3 flex h-75 items-center justify-center rounded-lg border">
-        <p className="text-grey-5 text-sm">
-          비밀번호 변경 컴포넌트가 들어올 영역입니다.
-        </p>
+type ErrorResponseData = {
+  error_detail?: string | Record<string, string[]>
+}
+
+export default function MyPasswordTab() {
+  const { mutate: changePassword, isPending } = useChangePassword()
+
+  const {
+    register,
+    handleSubmit,
+    reset,
+    setError,
+    clearErrors,
+    formState: { errors },
+  } = useForm<ChangePasswordFormValues>({
+    defaultValues: {
+      old_password: '',
+      new_password: '',
+      confirmPassword: '',
+    },
+    mode: 'onSubmit',
+    reValidateMode: 'onChange',
+  })
+
+  const handleChangePasswordError = (error: unknown) => {
+    if (axios.isAxiosError(error)) {
+      const responseData = error.response?.data as ErrorResponseData | undefined
+      const errorDetail = responseData?.error_detail
+
+      if (typeof errorDetail === 'string') {
+        toast.error(errorDetail)
+        return
+      }
+
+      if (errorDetail && typeof errorDetail === 'object') {
+        if (errorDetail.old_password?.[0]) {
+          setError('old_password', {
+            type: 'server',
+            message: errorDetail.old_password[0],
+          })
+        }
+
+        if (errorDetail.new_password?.[0]) {
+          setError('new_password', {
+            type: 'server',
+            message: errorDetail.new_password[0],
+          })
+        }
+
+        return
+      }
+    }
+
+    toast.error('비밀번호 변경에 실패했습니다.')
+  }
+
+  const onSubmit = (values: ChangePasswordFormValues) => {
+    clearErrors()
+
+    const parsed = changePasswordSchema.safeParse(values)
+
+    if (!parsed.success) {
+      changePasswordZodErrorsToRHF({
+        error: parsed.error,
+        setError,
+      })
+      return
+    }
+
+    changePassword(
+      {
+        old_password: parsed.data.old_password,
+        new_password: parsed.data.new_password,
+      },
+      {
+        onSuccess: (data) => {
+          toast.success(data.detail || '비밀번호 변경 성공')
+          reset()
+        },
+        onError: handleChangePasswordError,
+      }
+    )
+  }
+
+  return (
+    <section className="mb-40">
+      <h1 className="text-ui-gray-primary mb-5 text-[32px] font-bold">
+        비밀번호 변경
+      </h1>
+
+      <div className="border-grey-3 w-186 rounded-xl border px-11 py-13">
+        <form
+          onSubmit={handleSubmit(onSubmit)}
+          className="mx-auto flex flex-col"
+        >
+          <div className="mb-10 flex flex-col gap-5">
+            {PASSWORD_CHANGE_FIELDS.map(({ id, label, name, placeholder }) => (
+              <div
+                key={name}
+                className="grid grid-cols-[140px_1fr] items-start gap-6"
+              >
+                <label htmlFor={id} className="w-34 text-base font-normal">
+                  {label}
+                </label>
+
+                <InputField
+                  id={id}
+                  type="password"
+                  placeholder={placeholder}
+                  status={errors[name] ? 'danger' : 'default'}
+                  helperText={errors[name]?.message}
+                  {...register(name, {
+                    onChange: () => {
+                      clearErrors(name)
+
+                      if (name === 'new_password') {
+                        clearErrors('confirmPassword')
+                      }
+                    },
+                  })}
+                />
+              </div>
+            ))}
+          </div>
+          <div className="flex justify-end">
+            <Button
+              type="submit"
+              variant="fill"
+              size="md"
+              disabled={isPending}
+              className="cursor-pointer rounded-lg px-9 py-5 text-base font-semibold"
+            >
+              {isPending ? '변경 중...' : '변경하기'}
+            </Button>
+          </div>
+        </form>
       </div>
     </section>
   )

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -1,4 +1,5 @@
 import { availableCoursesHandlers } from './handlers/availableCoursesHandlers'
+import { changePasswordHandlers } from './handlers/changePasswordHandlers'
 import { examHandlers } from './handlers/examHandlers'
 import { mypageHandlers } from './handlers/myPageHandlers'
 
@@ -6,4 +7,5 @@ export const handlers = [
   ...examHandlers,
   ...mypageHandlers,
   ...availableCoursesHandlers,
+  ...changePasswordHandlers,
 ]

--- a/src/mocks/handlers/changePasswordHandlers.ts
+++ b/src/mocks/handlers/changePasswordHandlers.ts
@@ -1,0 +1,55 @@
+import { delay, http, HttpResponse } from 'msw'
+
+type ChangePasswordBody = {
+  old_password: string
+  new_password: string
+}
+
+export const changePasswordHandlers = [
+  http.post('/api/v1/accounts/change-password', async ({ request }) => {
+    await delay(500)
+
+    const body = (await request.json()) as ChangePasswordBody
+
+    const fieldErrors: Record<string, string[]> = {}
+
+    if (!body.old_password.trim()) {
+      fieldErrors.old_password = ['이 필드는 필수 항목입니다.']
+    }
+
+    if (!body.new_password.trim()) {
+      fieldErrors.new_password = ['이 필드는 필수 항목입니다.']
+    }
+
+    if (Object.keys(fieldErrors).length > 0) {
+      return HttpResponse.json(
+        {
+          error_detail: fieldErrors,
+        },
+        { status: 400 }
+      )
+    }
+
+    if (
+      !/^(?=.*[A-Za-z])(?=.*\d)(?=.*[^\w\s]).{6,15}$/.test(body.new_password)
+    ) {
+      return HttpResponse.json(
+        {
+          error_detail: {
+            new_password: [
+              '영문, 숫자, 특수문자를 포함한 6~15자로 입력해주세요.',
+            ],
+          },
+        },
+        { status: 400 }
+      )
+    }
+
+    return HttpResponse.json(
+      {
+        detail: '비밀번호 변경 성공.',
+      },
+      { status: 200 }
+    )
+  }),
+]

--- a/src/schemas/changePasswordSchema.ts
+++ b/src/schemas/changePasswordSchema.ts
@@ -1,0 +1,26 @@
+import { z } from 'zod'
+
+const passwordRegex = /^(?=.*[A-Za-z])(?=.*\d)(?=.*[^\w\s]).{6,15}$/
+
+export const changePasswordSchema = z
+  .object({
+    old_password: z.string().trim().min(1, '기존 비밀번호를 입력해주세요.'),
+    new_password: z
+      .string()
+      .trim()
+      .min(1, '새 비밀번호를 입력해주세요.')
+      .regex(
+        passwordRegex,
+        '영문, 숫자, 특수문자를 포함한 6~15자로 입력해주세요.'
+      ),
+    confirmPassword: z
+      .string()
+      .trim()
+      .min(1, '새 비밀번호를 한 번 더 입력해주세요.'),
+  })
+  .refine((data) => data.new_password === data.confirmPassword, {
+    message: '비밀번호와 비밀번호 확인값이 일치하지 않습니다.',
+    path: ['confirmPassword'],
+  })
+
+export type ChangePasswordFormValues = z.infer<typeof changePasswordSchema>

--- a/src/types/api-request/myPageRequest.ts
+++ b/src/types/api-request/myPageRequest.ts
@@ -19,3 +19,8 @@ export type DeleteMyAccountRequest = {
   reason: DeleteUserReason
   reason_detail: string
 }
+
+export type ChangePasswordRequest = {
+  old_password: string
+  new_password: string
+}

--- a/src/types/api-response/myPageResponse.ts
+++ b/src/types/api-response/myPageResponse.ts
@@ -29,3 +29,15 @@ export type EnrolledCourseResponse = {
     thumbnail_img_url: string
   }
 }
+
+export type ChangePasswordResponse = {
+  detail: string
+}
+
+export type ErrorDetailResponse =
+  | {
+      error_detail: string
+    }
+  | {
+      error_detail: Record<string, string[]>
+    }

--- a/src/utils/changePasswordZodErrorsToRHF.ts
+++ b/src/utils/changePasswordZodErrorsToRHF.ts
@@ -1,0 +1,29 @@
+import type { FieldValues, Path, UseFormSetError } from 'react-hook-form'
+import { z, type ZodError } from 'zod'
+
+type MapZodErrorsToRHFParams<TFieldValues extends FieldValues> = {
+  error: ZodError<TFieldValues>
+  setError: UseFormSetError<TFieldValues>
+}
+
+/**
+ * Zod 에러를 react-hook-form의 setError 형태로 변환해주는 함수
+ */
+export const changePasswordZodErrorsToRHF = <TFieldValues extends FieldValues>({
+  error,
+  setError,
+}: MapZodErrorsToRHFParams<TFieldValues>) => {
+  const { fieldErrors } = z.flattenError(error)
+
+  Object.entries(fieldErrors).forEach(([fieldName, messages]) => {
+    const firstMessage = messages?.[0]
+    if (!firstMessage) {
+      return
+    }
+
+    setError(fieldName as Path<TFieldValues>, {
+      type: 'manual',
+      message: firstMessage,
+    })
+  })
+}


### PR DESCRIPTION
## 📌 작업 내용

비밀번호 변경 관련 api 연결 및 msw 설정
- 비밀번호 변경 타입 정의
- 비밀번호 변경 API 함수와 Tanstack Query mutation 훅 추가
- 비밀번호 변경 요청/응답 타입 및 API 경로 추가
- MSW 비밀번호 변경 핸들러와 검증 에러 응답 목업 등록
- React-hook-form과 Zod 의존성 추가
 **(리베이스 후 --frozen-lockfile 진행 부탁드립니다.)**

비밀번호 변경 UI 및 클라이언트 검증 로직 구현
- 비밀번호 변경 입력 필드 상수 추가
- 마이페이지 비밀번호 변경 탭에 폼 UI 구현
- zod 기반 비밀번호 변경 스키마와 확인 비밀번호 검증 추가
- zod 에러를 react-hook-form 에러로 매핑하는 유틸 함수 구현
- API 에러 및 성공 처리

## 🔗 관련 이슈

- closes #63 

## 📸 스크린샷 (선택)
<img width="1106" height="579" alt="스크린샷 2026-03-17 오후 5 38 47" src="https://github.com/user-attachments/assets/61b9c1e6-429d-49f5-81b1-5376f88a9aa6" />

<img width="1106" height="579" alt="스크린샷 2026-03-17 오후 5 39 01" src="https://github.com/user-attachments/assets/63479d46-18dc-4850-8471-4471eda755c5" />

## ✅ 체크리스트

- [ ] 코드 컨벤션 확인
- [ ] lint 에러 없음
- [ ] 빌드 정상 확인
