### PR TITLE
feat: 비밀번호 찾기 모달 UI 구현

### DIFF
--- a/src/components/ui/modal/Modal.tsx
+++ b/src/components/ui/modal/Modal.tsx
@@ -9,6 +9,7 @@ type ModalProps = {
   children: ReactNode
   width?: string
   shadow?: boolean
+  dimmed?: boolean
 }
 
 export default function Modal({
@@ -17,6 +18,7 @@ export default function Modal({
   children,
   width,
   shadow = true,
+  dimmed = true,
 }: ModalProps) {
   useModalScroll(isOpen)
 
@@ -26,7 +28,10 @@ export default function Modal({
     <div
       role="dialog"
       aria-modal="true"
-      className="bg-ui-gray-primary/60 fixed inset-0 z-[1000] grid place-items-center p-4"
+      className={cn(
+        'fixed inset-0 z-[1000] grid place-items-center p-4',
+        dimmed ? 'bg-ui-gray-primary/60' : 'bg-transparent'
+      )}
     >
       <div
         className={cn(

--- a/src/components/ui/modal/Popup.tsx
+++ b/src/components/ui/modal/Popup.tsx
@@ -47,7 +47,7 @@ export default function Popup({
       aria-modal="true"
       className={cn(
         'fixed inset-0 z-[1001] flex items-center justify-center',
-        !isNested && 'bg-black/50'
+        !isNested && 'bg-ui-gray-primary/60'
       )}
       onClick={onClose}
     >

--- a/src/features/auth/find-password/FindPasswordModal.tsx
+++ b/src/features/auth/find-password/FindPasswordModal.tsx
@@ -1,0 +1,207 @@
+import { useEffect } from 'react'
+
+import FindIdIconSvg from '@/assets/icons/FindIdIcon.svg?react'
+import CheckToastIconSvg from '@/assets/icons/checkToast.svg?react'
+import CodeVerification from '@/components/common/CodeVerification'
+import Button from '@/components/ui/button'
+import Input from '@/components/ui/input'
+import Modal from '@/components/ui/modal/Modal'
+import Popup from '@/components/ui/modal/Popup'
+import { useFindPassword } from './useFindPassword'
+
+type FindPasswordModalProps = {
+  isOpen: boolean
+  onClose: () => void
+}
+
+const FindPasswordModal = ({ isOpen, onClose }: FindPasswordModalProps) => {
+  const {
+    step,
+    email,
+    newPassword,
+    confirmPassword,
+    code,
+    isCodeSent,
+    isCodeVerified,
+    codeErrorMessage,
+    findErrorMessage,
+    formattedTime,
+    isCompletePopupOpen,
+    handleEmailChange,
+    handleNewPasswordChange,
+    handleConfirmPasswordChange,
+    handleCodeChange,
+    handleSendCode,
+    handleVerifyCode,
+    handleNextStep,
+    handleResetPassword,
+    handleCloseCompletePopup,
+  } = useFindPassword({ isOpen })
+
+  useEffect(() => {
+    if (!isCompletePopupOpen) {
+      return
+    }
+
+    const timer = window.setTimeout(() => {
+      handleCloseCompletePopup()
+      onClose()
+    }, 1500)
+
+    return () => {
+      window.clearTimeout(timer)
+    }
+  }, [handleCloseCompletePopup, isCompletePopupOpen, onClose])
+
+  const renderHeader = (title: string, description: string) => {
+    return (
+      <div className="flex flex-col items-center gap-[16px] text-center">
+        <FindIdIconSvg className="h-[28px] w-[28px]" />
+
+        <div className="flex flex-col items-center gap-[12px]">
+          <h2 className="text-ui-gray-primary text-[20px] leading-[140%] font-bold tracking-[-0.03em]">
+            {title}
+          </h2>
+
+          <p className="text-ui-gray-600 text-[14px] leading-[140%] font-normal tracking-[-0.03em]">
+            {description}
+          </p>
+
+          {findErrorMessage && step === 'input' && (
+            <p className="text-other-red text-[14px] leading-[140%] font-normal tracking-[-0.03em] whitespace-pre-line">
+              {findErrorMessage}
+            </p>
+          )}
+        </div>
+      </div>
+    )
+  }
+
+  const renderInputStep = () => {
+    return (
+      <div className="flex flex-col gap-[32px] px-[24px] pb-[24px]">
+        {renderHeader('비밀번호 찾기', '이메일로 인증번호를 보내드려요.')}
+
+        <CodeVerification
+          label="이메일"
+          required
+          targetInputId="find-password-email"
+          targetValue={email}
+          onTargetChange={handleEmailChange}
+          targetPlaceholder="가입한 이메일을 입력해 주세요."
+          targetInputType="email"
+          targetInputMode="text"
+          verificationCodeInputId="find-password-code"
+          verificationCode={code}
+          onVerificationCodeChange={handleCodeChange}
+          verificationCodePlaceholder="인증번호 6자리를 입력해주세요"
+          onSendCode={handleSendCode}
+          onVerifyCode={handleVerifyCode}
+          isCodeSent={isCodeSent}
+          isCodeVerified={isCodeVerified}
+          errorMessage={codeErrorMessage}
+          successMessage="인증번호가 일치합니다."
+          formattedTime={formattedTime}
+        />
+
+        <Button
+          variant="fill"
+          size="full"
+          className="!h-[52px] !rounded-[4px] !p-0"
+          onClick={handleNextStep}
+        >
+          비밀번호 찾기
+        </Button>
+      </div>
+    )
+  }
+
+  const renderResetStep = () => {
+    return (
+      <div className="flex flex-col gap-[32px] px-[24px] pb-[24px]">
+        {renderHeader('비밀번호 재설정', '신규 비밀번호를 입력해주세요.')}
+
+        <div className="flex flex-col gap-[32px]">
+          <div className="flex flex-col gap-[16px]">
+            <div className="flex flex-wrap items-center gap-[8px]">
+              <label
+                htmlFor="find-password-new-password"
+                className="text-ui-gray-primary text-[16px] leading-[140%] font-normal tracking-[-0.03em]"
+              >
+                새 비밀번호<span className="text-other-red">*</span>
+              </label>
+
+              <span className="text-primary text-[14px] leading-[140%] font-semibold tracking-[-0.03em]">
+                6~15자의 영문 대소문자, 숫자, 특수문자 포함
+              </span>
+            </div>
+
+            <Input
+              id="find-password-new-password"
+              type="password"
+              value={newPassword}
+              onChange={(e) => handleNewPasswordChange(e.target.value)}
+              placeholder="비밀번호를 입력해주세요"
+              className="h-[48px]"
+            />
+          </div>
+
+          <div className="flex flex-col gap-[12px]">
+            <Input
+              id="find-password-confirm-password"
+              type="password"
+              value={confirmPassword}
+              onChange={(e) => handleConfirmPasswordChange(e.target.value)}
+              placeholder="비밀번호를 다시 입력해주세요"
+              className="h-[48px]"
+            />
+
+            {findErrorMessage && (
+              <p className="text-other-red text-[14px] leading-[140%] font-normal tracking-[-0.03em]">
+                {findErrorMessage}
+              </p>
+            )}
+          </div>
+        </div>
+
+        <Button
+          variant="fill"
+          size="full"
+          className="!h-[52px] !rounded-[4px] !p-0"
+          onClick={handleResetPassword}
+        >
+          확인
+        </Button>
+      </div>
+    )
+  }
+
+  return (
+    <>
+      <Modal isOpen={isOpen} onClose={onClose} width="w-[396px]">
+        {step === 'input' && renderInputStep()}
+        {step === 'reset' && renderResetStep()}
+      </Modal>
+
+      <Popup
+        isOpen={isCompletePopupOpen}
+        onClose={handleCloseCompletePopup}
+        isNested
+      >
+        <div className="flex w-[248px] flex-col items-center gap-[12px] px-[24px] py-[20px] text-center">
+          <CheckToastIconSvg className="h-[24px] w-[24px]" />
+
+          <h3 className="text-ui-gray-primary text-[20px] leading-[140%] font-bold tracking-[-0.03em]">
+            비밀번호 변경 완료!
+          </h3>
+
+          <p className="text-ui-gray-600 text-[14px] leading-[140%] font-normal tracking-[-0.03em]">
+            잠시 후 로그인 페이지로 이동합니다.
+          </p>
+        </div>
+      </Popup>
+    </>
+  )
+}
+
+export default FindPasswordModal

--- a/src/features/auth/find-password/FindPasswordModal.tsx
+++ b/src/features/auth/find-password/FindPasswordModal.tsx
@@ -31,7 +31,8 @@ const FindPasswordModal = ({
     isCodeSent,
     isCodeVerified,
     codeErrorMessage,
-    findErrorMessage,
+    inputErrorMessage,
+    resetErrorMessage,
     formattedTime,
     isCompletePopupOpen,
     handleEmailChange,
@@ -69,9 +70,9 @@ const FindPasswordModal = ({
               비밀번호 찾기
             </h2>
 
-            {findErrorMessage && (
+            {inputErrorMessage && (
               <p className="text-other-red text-[14px] leading-[140%] tracking-[-0.03em] whitespace-pre-line">
-                {findErrorMessage}
+                {inputErrorMessage}
               </p>
             )}
           </div>
@@ -170,9 +171,9 @@ const FindPasswordModal = ({
                 className="h-[48px]"
               />
 
-              {findErrorMessage && (
+              {resetErrorMessage && (
                 <p className="text-other-red text-[14px] leading-[140%] font-normal tracking-[-0.03em]">
-                  {findErrorMessage}
+                  {resetErrorMessage}
                 </p>
               )}
             </div>
@@ -207,6 +208,7 @@ const FindPasswordModal = ({
         isOpen={isOpen && isCompletePopupOpen}
         onClose={handleCloseCompletePopup}
         width="w-[396px]"
+        isNested
       >
         <div className="flex h-[128px] w-full items-center p-[24px]">
           <div className="flex w-full flex-col items-center gap-[16px] text-center">

--- a/src/features/auth/find-password/FindPasswordModal.tsx
+++ b/src/features/auth/find-password/FindPasswordModal.tsx
@@ -1,20 +1,27 @@
 import { useEffect } from 'react'
 
-import FindIdIconSvg from '@/assets/icons/FindIdIcon.svg?react'
-import CheckToastIconSvg from '@/assets/icons/checkToast.svg?react'
+import FindPasswordIconSvg from '@/assets/icons/FindPasswordIcon.svg?react'
 import CodeVerification from '@/components/common/CodeVerification'
 import Button from '@/components/ui/button'
 import Input from '@/components/ui/input'
 import Modal from '@/components/ui/modal/Modal'
 import Popup from '@/components/ui/modal/Popup'
-import { useFindPassword } from './useFindPassword'
+import {
+  useFindPassword,
+  type FindPasswordHandlers,
+} from '@/hooks/useFindPassword'
 
 type FindPasswordModalProps = {
   isOpen: boolean
   onClose: () => void
+  handlers: FindPasswordHandlers
 }
 
-const FindPasswordModal = ({ isOpen, onClose }: FindPasswordModalProps) => {
+const FindPasswordModal = ({
+  isOpen,
+  onClose,
+  handlers,
+}: FindPasswordModalProps) => {
   const {
     step,
     email,
@@ -36,12 +43,10 @@ const FindPasswordModal = ({ isOpen, onClose }: FindPasswordModalProps) => {
     handleNextStep,
     handleResetPassword,
     handleCloseCompletePopup,
-  } = useFindPassword({ isOpen })
+  } = useFindPassword({ isOpen, handlers })
 
   useEffect(() => {
-    if (!isCompletePopupOpen) {
-      return
-    }
+    if (!isCompletePopupOpen) return
 
     const timer = window.setTimeout(() => {
       handleCloseCompletePopup()
@@ -53,151 +58,178 @@ const FindPasswordModal = ({ isOpen, onClose }: FindPasswordModalProps) => {
     }
   }, [handleCloseCompletePopup, isCompletePopupOpen, onClose])
 
-  const renderHeader = (title: string, description: string) => {
-    return (
-      <div className="flex flex-col items-center gap-[16px] text-center">
-        <FindIdIconSvg className="h-[28px] w-[28px]" />
-
-        <div className="flex flex-col items-center gap-[12px]">
-          <h2 className="text-ui-gray-primary text-[20px] leading-[140%] font-bold tracking-[-0.03em]">
-            {title}
-          </h2>
-
-          <p className="text-ui-gray-600 text-[14px] leading-[140%] font-normal tracking-[-0.03em]">
-            {description}
-          </p>
-
-          {findErrorMessage && step === 'input' && (
-            <p className="text-other-red text-[14px] leading-[140%] font-normal tracking-[-0.03em] whitespace-pre-line">
-              {findErrorMessage}
-            </p>
-          )}
-        </div>
-      </div>
-    )
-  }
-
   const renderInputStep = () => {
     return (
-      <div className="flex flex-col gap-[32px] px-[24px] pb-[24px]">
-        {renderHeader('비밀번호 찾기', '이메일로 인증번호를 보내드려요.')}
+      <div className="flex flex-col gap-[40px] px-[24px] pb-[24px]">
+        <div className="flex flex-col items-center gap-[16px] text-center">
+          <FindPasswordIconSvg className="h-[28px] w-[28px]" />
 
-        <CodeVerification
-          label="이메일"
-          required
-          targetInputId="find-password-email"
-          targetValue={email}
-          onTargetChange={handleEmailChange}
-          targetPlaceholder="가입한 이메일을 입력해 주세요."
-          targetInputType="email"
-          targetInputMode="text"
-          verificationCodeInputId="find-password-code"
-          verificationCode={code}
-          onVerificationCodeChange={handleCodeChange}
-          verificationCodePlaceholder="인증번호 6자리를 입력해주세요"
-          onSendCode={handleSendCode}
-          onVerifyCode={handleVerifyCode}
-          isCodeSent={isCodeSent}
-          isCodeVerified={isCodeVerified}
-          errorMessage={codeErrorMessage}
-          successMessage="인증번호가 일치합니다."
-          formattedTime={formattedTime}
-        />
-
-        <Button
-          variant="fill"
-          size="full"
-          className="!h-[52px] !rounded-[4px] !p-0"
-          onClick={handleNextStep}
-        >
-          비밀번호 찾기
-        </Button>
-      </div>
-    )
-  }
-
-  const renderResetStep = () => {
-    return (
-      <div className="flex flex-col gap-[32px] px-[24px] pb-[24px]">
-        {renderHeader('비밀번호 재설정', '신규 비밀번호를 입력해주세요.')}
-
-        <div className="flex flex-col gap-[32px]">
-          <div className="flex flex-col gap-[16px]">
-            <div className="flex flex-wrap items-center gap-[8px]">
-              <label
-                htmlFor="find-password-new-password"
-                className="text-ui-gray-primary text-[16px] leading-[140%] font-normal tracking-[-0.03em]"
-              >
-                새 비밀번호<span className="text-other-red">*</span>
-              </label>
-
-              <span className="text-primary text-[14px] leading-[140%] font-semibold tracking-[-0.03em]">
-                6~15자의 영문 대소문자, 숫자, 특수문자 포함
-              </span>
-            </div>
-
-            <Input
-              id="find-password-new-password"
-              type="password"
-              value={newPassword}
-              onChange={(e) => handleNewPasswordChange(e.target.value)}
-              placeholder="비밀번호를 입력해주세요"
-              className="h-[48px]"
-            />
-          </div>
-
-          <div className="flex flex-col gap-[12px]">
-            <Input
-              id="find-password-confirm-password"
-              type="password"
-              value={confirmPassword}
-              onChange={(e) => handleConfirmPasswordChange(e.target.value)}
-              placeholder="비밀번호를 다시 입력해주세요"
-              className="h-[48px]"
-            />
+          <div className="flex flex-col items-center gap-[16px]">
+            <h2 className="text-ui-gray-primary text-[20px] leading-[140%] font-bold tracking-[-0.03em]">
+              비밀번호 찾기
+            </h2>
 
             {findErrorMessage && (
-              <p className="text-other-red text-[14px] leading-[140%] font-normal tracking-[-0.03em]">
+              <p className="text-other-red text-[14px] leading-[140%] tracking-[-0.03em] whitespace-pre-line">
                 {findErrorMessage}
               </p>
             )}
           </div>
         </div>
 
-        <Button
-          variant="fill"
-          size="full"
-          className="!h-[52px] !rounded-[4px] !p-0"
-          onClick={handleResetPassword}
-        >
-          확인
-        </Button>
+        <div className="flex flex-col gap-[40px]">
+          <CodeVerification
+            label="이메일"
+            required
+            targetInputId="find-password-email"
+            targetValue={email}
+            onTargetChange={handleEmailChange}
+            targetPlaceholder="가입한 이메일을 입력해 주세요."
+            targetInputType="email"
+            verificationCodeInputId="find-password-code"
+            verificationCode={code}
+            onVerificationCodeChange={handleCodeChange}
+            verificationCodePlaceholder="인증번호를 입력해주세요"
+            onSendCode={handleSendCode}
+            onVerifyCode={handleVerifyCode}
+            isCodeSent={isCodeSent}
+            isCodeVerified={isCodeVerified}
+            errorMessage={codeErrorMessage}
+            successMessage="인증번호가 일치합니다."
+            formattedTime={formattedTime}
+          />
+
+          <Button
+            variant="fill"
+            size="full"
+            className="!h-[52px] !rounded-[4px]"
+            onClick={handleNextStep}
+          >
+            비밀번호 찾기
+          </Button>
+        </div>
+      </div>
+    )
+  }
+
+  const renderResetStep = () => {
+    return (
+      <div className="flex flex-col gap-[40px] px-[24px] pb-[24px]">
+        <div className="flex flex-col items-center gap-[16px] text-center">
+          <FindPasswordIconSvg className="h-[28px] w-[28px]" />
+
+          <div className="flex flex-col items-center gap-[16px]">
+            <h2 className="text-ui-gray-primary text-[20px] leading-[140%] font-bold tracking-[-0.03em]">
+              비밀번호 재설정
+            </h2>
+
+            <p className="text-ui-gray-600 text-[14px] leading-[140%] font-normal tracking-[-0.03em]">
+              신규 비밀번호를 입력해주세요.
+            </p>
+          </div>
+        </div>
+
+        <div className="flex flex-col gap-[40px]">
+          <div className="flex flex-col gap-[16px]">
+            <div className="flex flex-col gap-[20px]">
+              <div className="flex items-start gap-[16px]">
+                <div className="flex w-[79px] items-start">
+                  <label
+                    htmlFor="find-password-new-password"
+                    className="text-ui-gray-primary text-[16px] leading-[140%] font-normal tracking-[-0.03em]"
+                  >
+                    새 비밀번호
+                  </label>
+                  <span className="text-other-red text-[16px] leading-[19px] tracking-[-0.02em]">
+                    *
+                  </span>
+                </div>
+
+                <span className="text-primary-default text-[14px] leading-[140%] font-semibold tracking-[-0.03em]">
+                  6~15자의 영문 대소문자, 숫자, 특수문자 포함
+                </span>
+              </div>
+
+              <Input
+                id="find-password-new-password"
+                type="password"
+                value={newPassword}
+                onChange={(e) => handleNewPasswordChange(e.target.value)}
+                placeholder="비밀번호를 입력해주세요"
+                className="h-[48px]"
+              />
+            </div>
+
+            <div className="flex flex-col gap-[16px]">
+              <Input
+                id="find-password-confirm-password"
+                type="password"
+                value={confirmPassword}
+                onChange={(e) => handleConfirmPasswordChange(e.target.value)}
+                placeholder="비밀번호를 다시 입력해주세요"
+                className="h-[48px]"
+              />
+
+              {findErrorMessage && (
+                <p className="text-other-red text-[14px] leading-[140%] font-normal tracking-[-0.03em]">
+                  {findErrorMessage}
+                </p>
+              )}
+            </div>
+          </div>
+
+          <Button
+            variant="fill"
+            size="full"
+            className="!h-[52px] !rounded-[4px] !p-0"
+            onClick={handleResetPassword}
+          >
+            확인
+          </Button>
+        </div>
       </div>
     )
   }
 
   return (
     <>
-      <Modal isOpen={isOpen} onClose={onClose} width="w-[396px]">
+      <Modal
+        isOpen={isOpen}
+        onClose={onClose}
+        width="w-[396px]"
+        dimmed={!isCompletePopupOpen}
+      >
         {step === 'input' && renderInputStep()}
         {step === 'reset' && renderResetStep()}
       </Modal>
 
       <Popup
-        isOpen={isCompletePopupOpen}
+        isOpen={isOpen && isCompletePopupOpen}
         onClose={handleCloseCompletePopup}
-        isNested
+        width="w-[396px]"
       >
-        <div className="flex w-[248px] flex-col items-center gap-[12px] px-[24px] py-[20px] text-center">
-          <CheckToastIconSvg className="h-[24px] w-[24px]" />
-
-          <h3 className="text-ui-gray-primary text-[20px] leading-[140%] font-bold tracking-[-0.03em]">
-            비밀번호 변경 완료!
-          </h3>
-
-          <p className="text-ui-gray-600 text-[14px] leading-[140%] font-normal tracking-[-0.03em]">
-            잠시 후 로그인 페이지로 이동합니다.
-          </p>
+        <div className="flex h-[128px] w-full items-center p-[24px]">
+          <div className="flex w-full flex-col items-center gap-[16px] text-center">
+            <div className="flex h-[24px] w-[24px] items-center justify-center rounded-full bg-[#14C786]">
+              <svg width="13" height="9" viewBox="0 0 13 9" fill="none">
+                <path
+                  d="M1.5 4.5L5 8L11.5 1"
+                  stroke="#FAFAFA"
+                  strokeWidth="1.5"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+              </svg>
+            </div>
+            <div className="flex flex-col items-center gap-[12px]">
+              <p className="text-ui-gray-primary text-[20px] leading-[140%] font-bold tracking-[-0.03em]">
+                비밀번호 변경 완료!
+              </p>
+              <p className="text-ui-gray-600 text-[14px] leading-[140%] font-normal tracking-[-0.03em]">
+                잠시 후 로그인 페이지로 이동합니다.
+              </p>
+            </div>
+          </div>
         </div>
       </Popup>
     </>

--- a/src/features/auth/find-password/FindPasswordModal.tsx
+++ b/src/features/auth/find-password/FindPasswordModal.tsx
@@ -208,7 +208,6 @@ const FindPasswordModal = ({
         isOpen={isOpen && isCompletePopupOpen}
         onClose={handleCloseCompletePopup}
         width="w-[396px]"
-        isNested
       >
         <div className="flex h-[128px] w-full items-center p-[24px]">
           <div className="flex w-full flex-col items-center gap-[16px] text-center">

--- a/src/features/auth/find-password/useFindPassword.ts
+++ b/src/features/auth/find-password/useFindPassword.ts
@@ -1,0 +1,187 @@
+import { useCallback, useEffect, useState } from 'react'
+
+import { usePhoneVerification } from '@/features/auth/hooks/usePhoneVerification'
+
+type Step = 'input' | 'reset'
+
+const PASSWORD_REGEX =
+  /^(?=.*[a-zA-Z])(?=.*\d)(?=.*[!@#$%^&*()_+\-=[\]{};':"\\|,.<>/?]).{6,15}$/
+
+type UseFindPasswordParams = {
+  isOpen: boolean
+}
+
+export const useFindPassword = ({ isOpen }: UseFindPasswordParams) => {
+  const [step, setStep] = useState<Step>('input')
+  const [email, setEmail] = useState('')
+  const [newPassword, setNewPassword] = useState('')
+  const [confirmPassword, setConfirmPassword] = useState('')
+  const [findErrorMessage, setFindErrorMessage] = useState('')
+  const [isCompletePopupOpen, setIsCompletePopupOpen] = useState(false)
+
+  const {
+    code,
+    isCodeSent,
+    isCodeVerified,
+    codeErrorMessage,
+    formattedTime,
+    handleCodeChange,
+    resetVerification,
+    markCodeSent,
+    markCodeVerified,
+    setVerificationError,
+    validateBeforeVerify,
+    validateBeforeSubmit,
+  } = usePhoneVerification()
+
+  useEffect(() => {
+    if (!isOpen) {
+      setStep('input')
+      setEmail('')
+      setNewPassword('')
+      setConfirmPassword('')
+      setFindErrorMessage('')
+      setIsCompletePopupOpen(false)
+      resetVerification()
+    }
+  }, [isOpen, resetVerification])
+
+  const handleEmailChange = (value: string) => {
+    setEmail(value)
+
+    if (findErrorMessage) {
+      setFindErrorMessage('')
+    }
+  }
+
+  const handleNewPasswordChange = (value: string) => {
+    setNewPassword(value)
+
+    if (findErrorMessage) {
+      setFindErrorMessage('')
+    }
+  }
+
+  const handleConfirmPasswordChange = (value: string) => {
+    setConfirmPassword(value)
+
+    if (findErrorMessage) {
+      setFindErrorMessage('')
+    }
+  }
+
+  const validateEmail = () => {
+    if (!email.trim()) {
+      setFindErrorMessage('이메일을 입력해주세요.')
+      return false
+    }
+
+    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
+
+    if (!emailRegex.test(email.trim())) {
+      setFindErrorMessage('올바른 이메일 형식을 입력해주세요.')
+      return false
+    }
+
+    return true
+  }
+
+  const handleSendCode = async () => {
+    if (!validateEmail()) {
+      return
+    }
+
+    setFindErrorMessage('')
+
+    // TODO: 인증코드 전송 API 연동
+    markCodeSent()
+  }
+
+  const handleVerifyCode = async () => {
+    if (!validateBeforeVerify()) {
+      return
+    }
+
+    // TODO: 인증코드 확인 API 연동
+    // 실패 시:
+    // setVerificationError('인증번호가 일치하지 않습니다.')
+    // return
+
+    markCodeVerified()
+  }
+
+  const handleNextStep = () => {
+    if (!validateEmail()) {
+      return
+    }
+
+    if (!validateBeforeSubmit()) {
+      return
+    }
+
+    setFindErrorMessage('')
+    setStep('reset')
+  }
+
+  const validatePassword = () => {
+    if (!newPassword.trim()) {
+      setFindErrorMessage('새 비밀번호를 입력해주세요.')
+      return false
+    }
+
+    if (!confirmPassword.trim()) {
+      setFindErrorMessage('비밀번호를 다시 입력해주세요.')
+      return false
+    }
+
+    if (!PASSWORD_REGEX.test(newPassword)) {
+      setFindErrorMessage('비밀번호 형식이 올바르지 않습니다.')
+      return false
+    }
+
+    if (newPassword !== confirmPassword) {
+      setFindErrorMessage('비밀번호가 일치하지 않습니다.')
+      return false
+    }
+
+    return true
+  }
+
+  const handleResetPassword = async () => {
+    if (!validatePassword()) {
+      return
+    }
+
+    // TODO: 비밀번호 변경 API 연동
+    setFindErrorMessage('')
+    setIsCompletePopupOpen(true)
+  }
+
+  const handleCloseCompletePopup = useCallback(() => {
+    setIsCompletePopupOpen(false)
+  }, [])
+
+  return {
+    step,
+    email,
+    newPassword,
+    confirmPassword,
+    code,
+    isCodeSent,
+    isCodeVerified,
+    codeErrorMessage,
+    findErrorMessage,
+    formattedTime,
+    isCompletePopupOpen,
+    handleEmailChange,
+    handleNewPasswordChange,
+    handleConfirmPasswordChange,
+    handleCodeChange,
+    handleSendCode,
+    handleVerifyCode,
+    handleNextStep,
+    handleResetPassword,
+    handleCloseCompletePopup,
+    setVerificationError,
+  }
+}

--- a/src/features/auth/recover-account/RecoverAccountModal.tsx
+++ b/src/features/auth/recover-account/RecoverAccountModal.tsx
@@ -141,11 +141,20 @@ const RecoverAccountModal = ({ isOpen, onClose }: RecoverAccountModalProps) => {
         </div>
       )}
 
+      <Modal
+        isOpen={isOpen}
+        onClose={onClose}
+        width="w-[396px]"
+        dimmed={!isCompletePopupVisible}
+      >
+        {step === 'inactive' && renderInactiveContent()}
+        {step === 'verify' && renderVerifyContent()}
+      </Modal>
+
       <Popup
         isOpen={isOpen && isCompletePopupVisible}
         onClose={closeCompletePopup}
         width="w-[396px]"
-        isNested
       >
         <div className="flex flex-col items-center gap-[10px] p-[24px] text-center">
           <div className="flex h-[24px] w-[24px] items-center justify-center rounded-full bg-[#14C786]">
@@ -170,13 +179,6 @@ const RecoverAccountModal = ({ isOpen, onClose }: RecoverAccountModalProps) => {
           </div>
         </div>
       </Popup>
-
-      <Modal isOpen={isOpen} onClose={onClose} width="w-[396px]">
-        {!isCompletePopupVisible &&
-          step === 'inactive' &&
-          renderInactiveContent()}
-        {!isCompletePopupVisible && step === 'verify' && renderVerifyContent()}
-      </Modal>
     </>
   )
 }

--- a/src/hooks/useFindId.ts
+++ b/src/hooks/useFindId.ts
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react'
+import { toast } from 'sonner'
 
 import { usePhoneVerification } from '@/hooks/usePhoneVerification'
 
@@ -101,6 +102,7 @@ export const useFindId = ({ isOpen, handlers }: UseFindIdParams) => {
     try {
       await handlers.onSendCode({ name, phone })
       markCodeSent()
+      toast.success('전송 완료! 인증번호를 확인해주세요.')
     } catch (error) {
       if (error instanceof Error) {
         setFindErrorMessage(error.message)
@@ -119,6 +121,7 @@ export const useFindId = ({ isOpen, handlers }: UseFindIdParams) => {
     try {
       await handlers.onVerifyCode({ code })
       markCodeVerified()
+      setFindErrorMessage('')
     } catch (error) {
       if (error instanceof Error) {
         setVerificationError(error.message)

--- a/src/hooks/useFindPassword.ts
+++ b/src/hooks/useFindPassword.ts
@@ -1,17 +1,31 @@
 import { useCallback, useEffect, useState } from 'react'
+import { toast } from 'sonner'
 
-import { usePhoneVerification } from '@/features/auth/hooks/usePhoneVerification'
+import { usePhoneVerification } from '@/hooks/usePhoneVerification'
 
 type Step = 'input' | 'reset'
 
 const PASSWORD_REGEX =
   /^(?=.*[a-zA-Z])(?=.*\d)(?=.*[!@#$%^&*()_+\-=[\]{};':"\\|,.<>/?]).{6,15}$/
 
-type UseFindPasswordParams = {
-  isOpen: boolean
+export type FindPasswordHandlers = {
+  onSendCode: (params: { email: string }) => Promise<void> | void
+  onVerifyCode: (params: { code: string }) => Promise<void> | void
+  onResetPassword: (params: {
+    email: string
+    newPassword: string
+  }) => Promise<void> | void
 }
 
-export const useFindPassword = ({ isOpen }: UseFindPasswordParams) => {
+type UseFindPasswordParams = {
+  isOpen: boolean
+  handlers: FindPasswordHandlers
+}
+
+export const useFindPassword = ({
+  isOpen,
+  handlers,
+}: UseFindPasswordParams) => {
   const [step, setStep] = useState<Step>('input')
   const [email, setEmail] = useState('')
   const [newPassword, setNewPassword] = useState('')
@@ -46,28 +60,25 @@ export const useFindPassword = ({ isOpen }: UseFindPasswordParams) => {
     }
   }, [isOpen, resetVerification])
 
-  const handleEmailChange = (value: string) => {
-    setEmail(value)
-
+  const clearFindErrorMessage = () => {
     if (findErrorMessage) {
       setFindErrorMessage('')
     }
+  }
+
+  const handleEmailChange = (value: string) => {
+    setEmail(value)
+    clearFindErrorMessage()
   }
 
   const handleNewPasswordChange = (value: string) => {
     setNewPassword(value)
-
-    if (findErrorMessage) {
-      setFindErrorMessage('')
-    }
+    clearFindErrorMessage()
   }
 
   const handleConfirmPasswordChange = (value: string) => {
     setConfirmPassword(value)
-
-    if (findErrorMessage) {
-      setFindErrorMessage('')
-    }
+    clearFindErrorMessage()
   }
 
   const validateEmail = () => {
@@ -84,43 +95,6 @@ export const useFindPassword = ({ isOpen }: UseFindPasswordParams) => {
     }
 
     return true
-  }
-
-  const handleSendCode = async () => {
-    if (!validateEmail()) {
-      return
-    }
-
-    setFindErrorMessage('')
-
-    // TODO: 인증코드 전송 API 연동
-    markCodeSent()
-  }
-
-  const handleVerifyCode = async () => {
-    if (!validateBeforeVerify()) {
-      return
-    }
-
-    // TODO: 인증코드 확인 API 연동
-    // 실패 시:
-    // setVerificationError('인증번호가 일치하지 않습니다.')
-    // return
-
-    markCodeVerified()
-  }
-
-  const handleNextStep = () => {
-    if (!validateEmail()) {
-      return
-    }
-
-    if (!validateBeforeSubmit()) {
-      return
-    }
-
-    setFindErrorMessage('')
-    setStep('reset')
   }
 
   const validatePassword = () => {
@@ -147,14 +121,76 @@ export const useFindPassword = ({ isOpen }: UseFindPasswordParams) => {
     return true
   }
 
+  const handleSendCode = async () => {
+    if (!validateEmail()) {
+      return
+    }
+
+    setFindErrorMessage('')
+
+    try {
+      await handlers.onSendCode({ email })
+      markCodeSent()
+      toast.success('전송 완료! 이메일을 확인해주세요.')
+    } catch (error) {
+      if (error instanceof Error) {
+        setFindErrorMessage(error.message)
+        return
+      }
+
+      setFindErrorMessage('인증코드 전송에 실패했습니다.')
+    }
+  }
+
+  const handleVerifyCode = async () => {
+    if (!validateBeforeVerify()) {
+      return
+    }
+
+    try {
+      await handlers.onVerifyCode({ code })
+      markCodeVerified()
+      setFindErrorMessage('')
+    } catch (error) {
+      if (error instanceof Error) {
+        setVerificationError(error.message)
+        return
+      }
+
+      setVerificationError('인증번호 확인에 실패했습니다.')
+    }
+  }
+
+  const handleNextStep = () => {
+    if (!validateEmail()) {
+      return
+    }
+
+    if (!validateBeforeSubmit()) {
+      return
+    }
+
+    setFindErrorMessage('')
+    setStep('reset')
+  }
+
   const handleResetPassword = async () => {
     if (!validatePassword()) {
       return
     }
 
-    // TODO: 비밀번호 변경 API 연동
-    setFindErrorMessage('')
-    setIsCompletePopupOpen(true)
+    try {
+      await handlers.onResetPassword({ email, newPassword })
+      setFindErrorMessage('')
+      setIsCompletePopupOpen(true)
+    } catch (error) {
+      if (error instanceof Error) {
+        setFindErrorMessage(error.message)
+        return
+      }
+
+      setFindErrorMessage('비밀번호 변경에 실패했습니다.')
+    }
   }
 
   const handleCloseCompletePopup = useCallback(() => {
@@ -182,6 +218,5 @@ export const useFindPassword = ({ isOpen }: UseFindPasswordParams) => {
     handleNextStep,
     handleResetPassword,
     handleCloseCompletePopup,
-    setVerificationError,
   }
 }

--- a/src/hooks/useFindPassword.ts
+++ b/src/hooks/useFindPassword.ts
@@ -5,6 +5,7 @@ import { usePhoneVerification } from '@/hooks/usePhoneVerification'
 
 type Step = 'input' | 'reset'
 
+const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
 const PASSWORD_REGEX =
   /^(?=.*[a-zA-Z])(?=.*\d)(?=.*[!@#$%^&*()_+\-=[\]{};':"\\|,.<>/?]).{6,15}$/
 
@@ -30,7 +31,8 @@ export const useFindPassword = ({
   const [email, setEmail] = useState('')
   const [newPassword, setNewPassword] = useState('')
   const [confirmPassword, setConfirmPassword] = useState('')
-  const [findErrorMessage, setFindErrorMessage] = useState('')
+  const [inputErrorMessage, setInputErrorMessage] = useState('')
+  const [resetErrorMessage, setResetErrorMessage] = useState('')
   const [isCompletePopupOpen, setIsCompletePopupOpen] = useState(false)
 
   const {
@@ -54,43 +56,48 @@ export const useFindPassword = ({
       setEmail('')
       setNewPassword('')
       setConfirmPassword('')
-      setFindErrorMessage('')
+      setInputErrorMessage('')
+      setResetErrorMessage('')
       setIsCompletePopupOpen(false)
       resetVerification()
     }
   }, [isOpen, resetVerification])
 
-  const clearFindErrorMessage = () => {
-    if (findErrorMessage) {
-      setFindErrorMessage('')
+  const clearInputErrorMessage = () => {
+    if (inputErrorMessage) {
+      setInputErrorMessage('')
+    }
+  }
+
+  const clearResetErrorMessage = () => {
+    if (resetErrorMessage) {
+      setResetErrorMessage('')
     }
   }
 
   const handleEmailChange = (value: string) => {
     setEmail(value)
-    clearFindErrorMessage()
+    clearInputErrorMessage()
   }
 
   const handleNewPasswordChange = (value: string) => {
     setNewPassword(value)
-    clearFindErrorMessage()
+    clearResetErrorMessage()
   }
 
   const handleConfirmPasswordChange = (value: string) => {
     setConfirmPassword(value)
-    clearFindErrorMessage()
+    clearResetErrorMessage()
   }
 
   const validateEmail = () => {
     if (!email.trim()) {
-      setFindErrorMessage('이메일을 입력해주세요.')
+      setInputErrorMessage('이메일을 입력해주세요.')
       return false
     }
 
-    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
-
-    if (!emailRegex.test(email.trim())) {
-      setFindErrorMessage('올바른 이메일 형식을 입력해주세요.')
+    if (!EMAIL_REGEX.test(email.trim())) {
+      setInputErrorMessage('올바른 이메일 형식을 입력해주세요.')
       return false
     }
 
@@ -99,22 +106,22 @@ export const useFindPassword = ({
 
   const validatePassword = () => {
     if (!newPassword.trim()) {
-      setFindErrorMessage('새 비밀번호를 입력해주세요.')
+      setResetErrorMessage('새 비밀번호를 입력해주세요.')
       return false
     }
 
     if (!confirmPassword.trim()) {
-      setFindErrorMessage('비밀번호를 다시 입력해주세요.')
+      setResetErrorMessage('비밀번호를 다시 입력해주세요.')
       return false
     }
 
     if (!PASSWORD_REGEX.test(newPassword)) {
-      setFindErrorMessage('비밀번호 형식이 올바르지 않습니다.')
+      setResetErrorMessage('비밀번호 형식이 올바르지 않습니다.')
       return false
     }
 
     if (newPassword !== confirmPassword) {
-      setFindErrorMessage('비밀번호가 일치하지 않습니다.')
+      setResetErrorMessage('비밀번호가 일치하지 않습니다.')
       return false
     }
 
@@ -126,7 +133,7 @@ export const useFindPassword = ({
       return
     }
 
-    setFindErrorMessage('')
+    setInputErrorMessage('')
 
     try {
       await handlers.onSendCode({ email })
@@ -134,11 +141,11 @@ export const useFindPassword = ({
       toast.success('전송 완료! 이메일을 확인해주세요.')
     } catch (error) {
       if (error instanceof Error) {
-        setFindErrorMessage(error.message)
+        setInputErrorMessage(error.message)
         return
       }
 
-      setFindErrorMessage('인증코드 전송에 실패했습니다.')
+      setInputErrorMessage('인증코드 전송에 실패했습니다.')
     }
   }
 
@@ -150,7 +157,7 @@ export const useFindPassword = ({
     try {
       await handlers.onVerifyCode({ code })
       markCodeVerified()
-      setFindErrorMessage('')
+      setInputErrorMessage('')
     } catch (error) {
       if (error instanceof Error) {
         setVerificationError(error.message)
@@ -170,7 +177,7 @@ export const useFindPassword = ({
       return
     }
 
-    setFindErrorMessage('')
+    setInputErrorMessage('')
     setStep('reset')
   }
 
@@ -181,15 +188,15 @@ export const useFindPassword = ({
 
     try {
       await handlers.onResetPassword({ email, newPassword })
-      setFindErrorMessage('')
+      setResetErrorMessage('')
       setIsCompletePopupOpen(true)
     } catch (error) {
       if (error instanceof Error) {
-        setFindErrorMessage(error.message)
+        setResetErrorMessage(error.message)
         return
       }
 
-      setFindErrorMessage('비밀번호 변경에 실패했습니다.')
+      setResetErrorMessage('비밀번호 변경에 실패했습니다.')
     }
   }
 
@@ -206,7 +213,8 @@ export const useFindPassword = ({
     isCodeSent,
     isCodeVerified,
     codeErrorMessage,
-    findErrorMessage,
+    inputErrorMessage,
+    resetErrorMessage,
     formattedTime,
     isCompletePopupOpen,
     handleEmailChange,

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -4,10 +4,12 @@ import { Link } from 'react-router-dom'
 import logoImg from '@/assets/images/logo.png'
 import { ROUTES_PATHS } from '@/constants/routesPaths'
 import FindIdModal from '@/features/auth/find-id/FindIdModal'
-import type { FindIdHandlers } from '@/hooks/useFindId'
+import FindPasswordModal from '@/features/auth/find-password/FindPasswordModal'
 import LoginForm from '@/features/auth/login/LoginForm'
 import SocialLoginButton from '@/features/auth/login/SocialLoginButton'
 import RecoverAccountModal from '@/features/auth/recover-account/RecoverAccountModal'
+import type { FindIdHandlers } from '@/hooks/useFindId'
+import type { FindPasswordHandlers } from '@/hooks/useFindPassword'
 
 type SubmitLoginParams = {
   email: string
@@ -16,7 +18,6 @@ type SubmitLoginParams = {
 
 type Provider = 'kakao' | 'naver'
 
-// TODO: API 연동 시 실제 서버 호출로 교체
 const findIdHandlers: FindIdHandlers = {
   onSendCode: async () => {
     throw new Error(
@@ -35,9 +36,24 @@ const findIdHandlers: FindIdHandlers = {
   },
 }
 
+const findPasswordHandlers: FindPasswordHandlers = {
+  onSendCode: async () => {
+    throw new Error('등록된 이메일이 아닙니다.')
+  },
+
+  onVerifyCode: async () => {
+    throw new Error('인증번호가 일치하지 않습니다.')
+  },
+
+  onResetPassword: async () => {
+    return
+  },
+}
+
 const LoginPage = () => {
   const [isRecoverModalOpen, setIsRecoverModalOpen] = useState(false)
   const [isFindIdModalOpen, setIsFindIdModalOpen] = useState(false)
+  const [isFindPasswordModalOpen, setIsFindPasswordModalOpen] = useState(false)
 
   const handleSocialLoginBtnClick = ({ provider }: { provider: Provider }) => {
     void provider
@@ -54,7 +70,7 @@ const LoginPage = () => {
   }
 
   const handleFindPasswordBtnClick = () => {
-    // TODO: 비밀번호 찾기 모달 구현 후 연결 예정
+    setIsFindPasswordModalOpen(true)
   }
 
   return (
@@ -105,9 +121,15 @@ const LoginPage = () => {
         onClose={() => setIsFindIdModalOpen(false)}
         onFindPassword={() => {
           setIsFindIdModalOpen(false)
-          // TODO: 비밀번호 찾기 모달 구현 후 연결 예정
+          setIsFindPasswordModalOpen(true)
         }}
         handlers={findIdHandlers}
+      />
+
+      <FindPasswordModal
+        isOpen={isFindPasswordModalOpen}
+        onClose={() => setIsFindPasswordModalOpen(false)}
+        handlers={findPasswordHandlers}
       />
     </div>
   )

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -18,6 +18,8 @@ type SubmitLoginParams = {
 
 type Provider = 'kakao' | 'naver'
 
+type OpenModal = 'none' | 'recover' | 'findId' | 'findPassword'
+
 const findIdHandlers: FindIdHandlers = {
   onSendCode: async () => {
     throw new Error(
@@ -46,14 +48,12 @@ const findPasswordHandlers: FindPasswordHandlers = {
   },
 
   onResetPassword: async () => {
-    return
+    // TODO: 비밀번호 재설정 API 연동
   },
 }
 
 const LoginPage = () => {
-  const [isRecoverModalOpen, setIsRecoverModalOpen] = useState(false)
-  const [isFindIdModalOpen, setIsFindIdModalOpen] = useState(false)
-  const [isFindPasswordModalOpen, setIsFindPasswordModalOpen] = useState(false)
+  const [openModal, setOpenModal] = useState<OpenModal>('none')
 
   const handleSocialLoginBtnClick = ({ provider }: { provider: Provider }) => {
     void provider
@@ -66,11 +66,11 @@ const LoginPage = () => {
   }
 
   const handleFindIdBtnClick = () => {
-    setIsFindIdModalOpen(true)
+    setOpenModal('findId')
   }
 
   const handleFindPasswordBtnClick = () => {
-    setIsFindPasswordModalOpen(true)
+    setOpenModal('findPassword')
   }
 
   return (
@@ -112,23 +112,20 @@ const LoginPage = () => {
       </div>
 
       <RecoverAccountModal
-        isOpen={isRecoverModalOpen}
-        onClose={() => setIsRecoverModalOpen(false)}
+        isOpen={openModal === 'recover'}
+        onClose={() => setOpenModal('none')}
       />
 
       <FindIdModal
-        isOpen={isFindIdModalOpen}
-        onClose={() => setIsFindIdModalOpen(false)}
-        onFindPassword={() => {
-          setIsFindIdModalOpen(false)
-          setIsFindPasswordModalOpen(true)
-        }}
+        isOpen={openModal === 'findId'}
+        onClose={() => setOpenModal('none')}
+        onFindPassword={() => setOpenModal('findPassword')}
         handlers={findIdHandlers}
       />
 
       <FindPasswordModal
-        isOpen={isFindPasswordModalOpen}
-        onClose={() => setIsFindPasswordModalOpen(false)}
+        isOpen={openModal === 'findPassword'}
+        onClose={() => setOpenModal('none')}
         handlers={findPasswordHandlers}
       />
     </div>

--- a/src/pages/TestPage.tsx
+++ b/src/pages/TestPage.tsx
@@ -1,7 +1,6 @@
 import Dropdown from '@/components/common/Dropdown'
 import Toast from '@/components/common/Toast'
 import TestButton from '@/test/TestButton'
-import TestFindIdModal from '@/test/TestFindIdModal'
 import TestInput from '@/test/TestInput'
 import TestModal from '@/test/TestModal'
 import TestFindIdModal from '@/test/TestFindIdModal'
@@ -21,9 +20,7 @@ function TestPage() {
       <TestFindPasswordModal />
       <TestRecoverAccountModal />
 
-      <div className="flex min-h-90 items-center justify-center">
-        <ExamEmptyState />
-      </div>
+      <div className="flex min-h-90 items-center justify-center"></div>
     </div>
   )
 }

--- a/src/pages/TestPage.tsx
+++ b/src/pages/TestPage.tsx
@@ -4,6 +4,9 @@ import TestButton from '@/test/TestButton'
 import TestFindIdModal from '@/test/TestFindIdModal'
 import TestInput from '@/test/TestInput'
 import TestModal from '@/test/TestModal'
+import TestFindIdModal from '@/test/TestFindIdModal'
+import TestFindPasswordModal from '@/test/TestFindPasswordModal'
+import TestRecoverAccountModal from '@/test/TestRecoverAccountModal'
 
 function TestPage() {
   return (
@@ -15,6 +18,12 @@ function TestPage() {
       <TestInput />
       <TestModal />
       <TestFindIdModal />
+      <TestFindPasswordModal />
+      <TestRecoverAccountModal />
+
+      <div className="flex min-h-90 items-center justify-center">
+        <ExamEmptyState />
+      </div>
     </div>
   )
 }

--- a/src/test/TestFindPasswordModal.tsx
+++ b/src/test/TestFindPasswordModal.tsx
@@ -1,0 +1,23 @@
+import { useState } from 'react'
+
+import FindPasswordModal from '@/features/auth/find-password/FindPasswordModal'
+
+const TestFindPasswordModal = () => {
+  const [isOpen, setIsOpen] = useState(false)
+
+  return (
+    <div className="flex gap-4">
+      <button
+        type="button"
+        onClick={() => setIsOpen(true)}
+        className="rounded border p-2"
+      >
+        비밀번호 찾기 모달 (테스트)
+      </button>
+
+      <FindPasswordModal isOpen={isOpen} onClose={() => setIsOpen(false)} />
+    </div>
+  )
+}
+
+export default TestFindPasswordModal

--- a/src/test/TestFindPasswordModal.tsx
+++ b/src/test/TestFindPasswordModal.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react'
 
 import FindPasswordModal from '@/features/auth/find-password/FindPasswordModal'
+import { findPasswordMockHandlers } from '@/test/mocks/findPasswordMockHandlers'
 
 const TestFindPasswordModal = () => {
   const [isOpen, setIsOpen] = useState(false)
@@ -15,7 +16,11 @@ const TestFindPasswordModal = () => {
         비밀번호 찾기 모달 (테스트)
       </button>
 
-      <FindPasswordModal isOpen={isOpen} onClose={() => setIsOpen(false)} />
+      <FindPasswordModal
+        isOpen={isOpen}
+        onClose={() => setIsOpen(false)}
+        handlers={findPasswordMockHandlers}
+      />
     </div>
   )
 }

--- a/src/test/mocks/findPasswordMockHandlers.ts
+++ b/src/test/mocks/findPasswordMockHandlers.ts
@@ -1,0 +1,21 @@
+import type { FindPasswordHandlers } from '@/hooks/useFindPassword'
+
+export const findPasswordMockHandlers: FindPasswordHandlers = {
+  onSendCode: async ({ email }) => {
+    if (email.trim() !== 'test@test.com') {
+      throw new Error('등록된 이메일이 아닙니다.')
+    }
+  },
+
+  onVerifyCode: async ({ code }) => {
+    if (code.trim() !== '123456') {
+      throw new Error('인증번호가 일치하지 않습니다.')
+    }
+  },
+
+  onResetPassword: async ({ newPassword }) => {
+    if (newPassword.trim() === 'Fail123!') {
+      throw new Error('비밀번호 변경에 실패했습니다.')
+    }
+  },
+}


### PR DESCRIPTION
## 📌 작업 내용

- 비밀번호 찾기 모달 UI 및 인증 플로우 구현
- useFindPassword 훅 분리로 상태 및 검증 로직 분리
- 비밀번호 재설정 완료 팝업 UI 구현
- Modal dimmed prop 추가로 팝업 중첩 시 딤 처리 개선
- Popup 딤 색상을 Modal과 동일하게 적용 (bg-ui-gray-primary/60)
- 로그인 페이지 내 아이디 찾기 / 비밀번호 찾기 mock 핸들러 적용
- 비밀번호 찾기 에러 상태를 step 기준으로 분리 (`inputErrorMessage`, `resetErrorMessage`)
- 이메일 정규식을 상수(`EMAIL_REGEX`)로 분리

** 논의하고 싶은 부분 **
1. 정규식 및 에러 메시지를 constants로 분리하는 것이 좋을지
2. mock 핸들러를 페이지 내부에 둘지, 별도 파일로 분리하는 것이 좋을지

## 🔗 관련 이슈

- closes #54

## 📸 스크린샷 (선택)
<img width="626" height="627" alt="스크린샷 2026-03-17 오후 10 51 11" src="https://github.com/user-attachments/assets/2558ba8c-6b2e-4002-9a66-299904262247" />

<img width="611" height="588" alt="스크린샷 2026-03-17 오후 10 51 34" src="https://github.com/user-attachments/assets/4d4831e1-cdd1-4d91-82fb-76db60c46932" />

<img width="696" height="622" alt="스크린샷 2026-03-17 오후 10 51 52" src="https://github.com/user-attachments/assets/94786cde-9708-4308-ab67-e53e676e1045" />

## ✅ 체크리스트

- [ ] 코드 컨벤션 확인
- [ ] lint 에러 없음
- [ ] 빌드 정상 확인



