### PR TITLE
feat: 쪽지시험 예외처리 추가 

### DIFF
--- a/src/components/exam/ExamEmptyState.tsx
+++ b/src/components/exam/ExamEmptyState.tsx
@@ -1,13 +1,15 @@
 import NotExamIcon from '@/assets/images/not-exam-icon.svg?react'
 import EmptyState from '../common/EmptyState'
 
+type ExamEmptyStateProps = {
+  title: string
+}
+
 /**
  * ExamEmptyState
- * 응시 할 시험이 없을 경우 사용되는 컴포넌트
+ * 쪽지시험 데이터가 없을 경우 사용되는 컴포넌트
  * 부모 컨테이너에서 높이 조절
  */
-export default function ExamEmptyState() {
-  return (
-    <EmptyState icon={<NotExamIcon />} title="아직 응시 할 시험이 없어요." />
-  )
+export default function ExamEmptyState({ title }: ExamEmptyStateProps) {
+  return <EmptyState icon={<NotExamIcon />} title={title} />
 }

--- a/src/constants/examTab.ts
+++ b/src/constants/examTab.ts
@@ -2,6 +2,12 @@ import type { ExamTabType } from '@/types/mypage-type/examDeployment'
 
 export const EXAM_TABS: ExamTabType[] = ['all', 'done', 'pending']
 
+export const EMPTY_TITLE_MAP = {
+  all: '아직 응시할 시험이 없어요.',
+  done: '아직 응시 완료한 시험이 없어요.',
+  pending: '현재 응시할 시험이 없어요.',
+} as const
+
 export const EXAM_TAB_LABEL = {
   all: '전체보기',
   done: '응시완료',

--- a/src/features/mypage/MyExamTab.tsx
+++ b/src/features/mypage/MyExamTab.tsx
@@ -1,6 +1,7 @@
 import ExamEmptyState from '@/components/exam/ExamEmptyState'
 import { EXAM_SUBJECT_ICON_MAP } from '@/constants/examSubjectIconMap'
 import {
+  EMPTY_TITLE_MAP,
   EXAM_STATUS_META,
   EXAM_TAB_LABEL,
   EXAM_TABS,
@@ -11,6 +12,12 @@ import { mockExamDeploymentList } from '@/mocks/data/mockExamDeploymentList'
 import type { ExamTabType } from '@/types/mypage-type/examDeployment'
 import { useState } from 'react'
 import { Link } from 'react-router-dom'
+
+const emptyTitleMap = {
+  all: '아직 응시할 시험이 없어요.',
+  done: '아직 응시 완료한 시험이 없어요.',
+  pending: '현재 응시할 시험이 없어요.',
+} as const
 
 export default function MyExamTab() {
   const [activeTab, setActiveTab] = useState<ExamTabType>('all')
@@ -60,7 +67,7 @@ export default function MyExamTab() {
       {/* 콘텐츠(시험과목) 영역 */}
       <div className="mt-6">
         {filteredExamList.length === 0 ? (
-          <ExamEmptyState />
+          <ExamEmptyState title={EMPTY_TITLE_MAP[activeTab]} />
         ) : (
           <ul className="flex flex-col gap-4">
             {filteredExamList.map((item) => {

--- a/src/features/mypage/MyExamTab.tsx
+++ b/src/features/mypage/MyExamTab.tsx
@@ -1,14 +1,16 @@
-import { useState } from 'react'
+import ExamEmptyState from '@/components/exam/ExamEmptyState'
 import { EXAM_SUBJECT_ICON_MAP } from '@/constants/examSubjectIconMap'
-import type { ExamTabType } from '@/types/mypage-type/examDeployment'
-import { mockExamDeploymentList } from '@/mocks/data/mockExamDeploymentList'
 import {
   EXAM_STATUS_META,
   EXAM_TAB_LABEL,
   EXAM_TABS,
 } from '@/constants/examTab'
-import { Link } from 'react-router-dom'
 import { getQuizPage, getQuizResultPage } from '@/constants/routesPaths'
+import { cn } from '@/lib/utils'
+import { mockExamDeploymentList } from '@/mocks/data/mockExamDeploymentList'
+import type { ExamTabType } from '@/types/mypage-type/examDeployment'
+import { useState } from 'react'
+import { Link } from 'react-router-dom'
 
 export default function MyExamTab() {
   const [activeTab, setActiveTab] = useState<ExamTabType>('all')
@@ -16,7 +18,6 @@ export default function MyExamTab() {
     if (activeTab === 'all') {
       return true
     }
-
     return item.exam_info.status === activeTab
   })
   return (
@@ -42,7 +43,7 @@ export default function MyExamTab() {
                       setActiveTab(tab)
                     }}
                     aria-pressed={isActive}
-                    className={`border-b-2 p-4 ${
+                    className={`cursor-pointer border-b-2 p-4 ${
                       isActive
                         ? 'border-[#721AE3] text-[#721AE3]'
                         : 'border-transparent text-gray-400 hover:text-[#721AE3]'
@@ -58,65 +59,70 @@ export default function MyExamTab() {
       </div>
       {/* 콘텐츠(시험과목) 영역 */}
       <div className="mt-6">
-        <ul className="flex flex-col gap-4">
-          {filteredExamList.map((item) => {
-            // 과목명에 맞는 아이콘과 시험 상태별 UI 메타 정보를 가져옴, ts검증
-            const subjectTitle = item.exam.subject
-              .title as keyof typeof EXAM_SUBJECT_ICON_MAP
-            const subjectIcon = EXAM_SUBJECT_ICON_MAP[subjectTitle]
-            const statusMeta = EXAM_STATUS_META[item.exam_info.status]
-            const isDone = item.exam_info.status === 'done'
-            // 아직 api data로 이동 X
-            const buttonPath = isDone
-              ? getQuizResultPage(item.id)
-              : getQuizPage(item.id)
+        {filteredExamList.length === 0 ? (
+          <ExamEmptyState />
+        ) : (
+          <ul className="flex flex-col gap-4">
+            {filteredExamList.map((item) => {
+              // 과목명에 맞는 아이콘과 시험 상태별 UI 메타 정보를 가져옴, ts검증
+              const subjectTitle = item.exam.subject
+                .title as keyof typeof EXAM_SUBJECT_ICON_MAP
+              const subjectIcon = EXAM_SUBJECT_ICON_MAP[subjectTitle]
+              const statusMeta = EXAM_STATUS_META[item.exam_info.status]
+              const isDone = item.exam_info.status === 'done'
+              // 아직 api data로 이동 X
+              const buttonPath = isDone
+                ? getQuizResultPage(item.id)
+                : getQuizPage(item.id)
 
-            return (
-              <li
-                key={item.id}
-                className="flex items-center gap-4 rounded-lg border px-8 py-7"
-              >
-                <img src={subjectIcon} alt="" className="h-12 w-12" />
-
-                <div className="flex-1">
-                  <div className="flex items-center gap-3">
-                    <h3 className="text-[18px] leading-[140%] font-semibold tracking-[-0.03em]">
-                      {item.exam.title}
-                    </h3>
-                    <p
-                      className={`flex items-center justify-center rounded-[2px] px-2 py-1 text-[12px] ${statusMeta.badgeClassName}`}
-                    >
-                      {statusMeta.label}
-                    </p>
-                  </div>
-
-                  <div className="text-[14px] leading-[140%] font-normal tracking-[-0.03em] text-gray-700">
-                    {isDone ? (
-                      <p>
-                        {item.exam.subject.title} ㆍ {item.exam_info.score}점/
-                        {item.total_score}점 ㆍ{' '}
-                        {item.exam_info.correct_answer_count}/
-                        {item.question_count}개 정답
-                      </p>
-                    ) : (
-                      <p>
-                        {item.exam.subject.title} ㆍ 응시하고 점수를
-                        확인해보세요!
-                      </p>
-                    )}
-                  </div>
-                </div>
-                {/* 버튼영역 */}
-                <Link
-                  to={buttonPath}
-                  className={`${statusMeta.buttonClassName} shrink-0`}
+              return (
+                <li
+                  key={item.id}
+                  className="flex items-center gap-4 rounded-lg border px-8 py-7"
                 >
-                  {statusMeta.buttonText}
-                </Link>
-              </li>
-            )
-          })}
-        </ul>
+                  <img src={subjectIcon} alt="" className="h-12 w-12" />
+                  <div className="flex-1 flex-col">
+                    <div className="mb-2 flex items-center gap-3">
+                      <h3 className="text-[18px] leading-[140%] font-semibold tracking-[-0.03em]">
+                        {item.exam.title}
+                      </h3>
+                      <p
+                        className={cn(
+                          'flex items-center justify-center rounded-[2px] px-2 py-1 text-[12px]',
+                          statusMeta.badgeClassName
+                        )}
+                      >
+                        {statusMeta.label}
+                      </p>
+                    </div>
+                    <div className="text-[14px] leading-[140%] font-normal tracking-[-0.03em] text-gray-700">
+                      {isDone ? (
+                        <p>
+                          {item.exam.subject.title} ㆍ {item.exam_info.score}점/
+                          {item.total_score}점 ㆍ{' '}
+                          {item.exam_info.correct_answer_count}/
+                          {item.question_count}개 정답
+                        </p>
+                      ) : (
+                        <p>
+                          {item.exam.subject.title} ㆍ 응시하고 점수를
+                          확인해보세요!
+                        </p>
+                      )}
+                    </div>
+                  </div>
+                  {/* 버튼영역 */}
+                  <Link
+                    to={buttonPath}
+                    className={`${statusMeta.buttonClassName} shrink-0`}
+                  >
+                    {statusMeta.buttonText}
+                  </Link>
+                </li>
+              )
+            })}
+          </ul>
+        )}
       </div>
     </section>
   )

--- a/src/features/mypage/MyExamTab.tsx
+++ b/src/features/mypage/MyExamTab.tsx
@@ -13,12 +13,6 @@ import type { ExamTabType } from '@/types/mypage-type/examDeployment'
 import { useState } from 'react'
 import { Link } from 'react-router-dom'
 
-const emptyTitleMap = {
-  all: '아직 응시할 시험이 없어요.',
-  done: '아직 응시 완료한 시험이 없어요.',
-  pending: '현재 응시할 시험이 없어요.',
-} as const
-
 export default function MyExamTab() {
   const [activeTab, setActiveTab] = useState<ExamTabType>('all')
   const filteredExamList = mockExamDeploymentList.results.filter((item) => {

--- a/src/mocks/data/mockExamDeploymentList.ts
+++ b/src/mocks/data/mockExamDeploymentList.ts
@@ -20,7 +20,7 @@ export const mockExamDeploymentList: ExamDeploymentListResponse = {
       question_count: 10,
       total_score: 100,
       exam_info: {
-        status: 'done',
+        status: 'pending',
         score: 80,
         correct_answer_count: 8,
       },

--- a/src/pages/TestPage.tsx
+++ b/src/pages/TestPage.tsx
@@ -1,10 +1,9 @@
 import Dropdown from '@/components/common/Dropdown'
 import Toast from '@/components/common/Toast'
-import ExamEmptyState from '@/components/exam/ExamEmptyState'
 import TestButton from '@/test/TestButton'
+import TestFindIdModal from '@/test/TestFindIdModal'
 import TestInput from '@/test/TestInput'
 import TestModal from '@/test/TestModal'
-import TestFindIdModal from '@/test/TestFindIdModal'
 
 function TestPage() {
   return (
@@ -16,9 +15,6 @@ function TestPage() {
       <TestInput />
       <TestModal />
       <TestFindIdModal />
-      <div className="flex min-h-90 items-center justify-center">
-        <ExamEmptyState />
-      </div>
     </div>
   )
 }


### PR DESCRIPTION
## 📌 작업 내용
- 마이페이지 쪽지시험 탭 내 empty state UI 추가

- 전체 데이터가 없을 경우 empty state가 노출되도록 분기 처리

- 응시완료 / 미응시 탭에 해당하는 데이터가 없을 경우 상태별 empty state 문구가 보이도록 처리

- 쪽지시험 전용 empty state 컴포넌트를 exam 폴더 구조에 맞게 연결

## 🔗 관련 이슈

- closes #74 

## 📸 스크린샷 (선택)
<img width="1034" height="404" alt="image" src="https://github.com/user-attachments/assets/dacf800b-f21a-4c90-9fd7-4cae8fbaf951" />

## ✅ 체크리스트

- [ ] 코드 컨벤션 확인
- [ ] lint 에러 없음
- [ ] 빌드 정상 확인
