### PR TITLE
feat: 시험응시 back 구현 (#72)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -23,9 +23,9 @@ function App() {
       </Route>
 
       <Route element={<QuizLayout />}>
-        <Route path={ROUTES_PATHS.QUIZ_PAGE} element={<QuizPage />} />
+        <Route path={`${ROUTES_PATHS.QUIZ_PAGE}/:id`} element={<QuizPage />} />
         <Route
-          path={ROUTES_PATHS.QUIZ_RESULT_PAGE}
+          path={`${ROUTES_PATHS.QUIZ_RESULT_PAGE}/:id`}
           element={<QuizResultPage />}
         />
       </Route>

--- a/src/components/layout/quiz/QuizHeader.tsx
+++ b/src/components/layout/quiz/QuizHeader.tsx
@@ -1,6 +1,6 @@
-import type { QuizHeaderProps } from '@/types/quizpage-type/quizHeader'
 import ArrowIcon from '@/assets/icons/quiz/arrow-left.svg?react'
 import WarningIcon from '@/assets/icons/quiz/warningIcon.svg?react'
+import type { QuizHeaderProps } from '@/types/quizpage-type/quizHeader'
 
 export default function QuizHeader({
   variant,

--- a/src/pages/QuizPage.tsx
+++ b/src/pages/QuizPage.tsx
@@ -1,14 +1,14 @@
+import { getExamQuestions } from '@/api/exam'
 import AlertIcon from '@/assets/icons/quiz/alert-circle.png'
 import CloseIcon from '@/assets/icons/quiz/icon-x-gray.svg?react'
-import { useEffect, useState, useCallback } from 'react'
-import { useNavigate } from 'react-router'
-import { getExamQuestions } from '@/api/exam'
-import type { QuizData } from '@/types/quizpage-type/question'
 import QuizHeader from '@/components/layout/quiz/QuizHeader'
-import { QuestionItem } from '@/features/quiz'
 import Button from '@/components/ui/button'
+import { getQuizResultPage } from '@/constants/routesPaths'
+import { QuestionItem } from '@/features/quiz'
 import { useQuizTimer } from '@/hooks/useQuizTimer'
-import { ROUTES_PATHS } from '@/constants/routesPaths'
+import type { QuizData } from '@/types/quizpage-type/question'
+import { useCallback, useEffect, useState } from 'react'
+import { useNavigate } from 'react-router-dom'
 
 function QuizPage() {
   const [quizData, setQuizData] = useState<QuizData | null>(null)
@@ -16,15 +16,16 @@ function QuizPage() {
   const [isSubmitting, setIsSubmitting] = useState(false)
 
   const navigate = useNavigate()
-
+  const handleBack = () => {
+    navigate('/mypage?tab=exam')
+  }
   const handleSubmit = useCallback(async () => {
     if (isSubmitting) {
       return
     }
     setIsSubmitting(true)
     try {
-      // TODO: 저장된 풀이 데이터 제출 API 연결
-      navigate(ROUTES_PATHS.QUIZ_RESULT_PAGE)
+      navigate(getQuizResultPage(1))
     } catch (error) {
       console.error(error)
       setIsSubmitting(false)
@@ -61,7 +62,7 @@ function QuizPage() {
         title="TypeScript 쪽지시험"
         subText="집중해서 천천히, 끝까지 응시해 주세요. 응원할게요💪"
         timeText={`${formattedTime} 뒤에 끝나요`}
-        misconductCount={0}
+        onBack={handleBack}
       />
       {/* 경고창 */}
       <section className="px-90 pt-32">

--- a/src/types/quizpage-type/quizHeader.ts
+++ b/src/types/quizpage-type/quizHeader.ts
@@ -8,5 +8,4 @@ export type QuizHeaderProps = {
   timeText?: string
   misconductCount?: number
   onBack?: () => void
-  onMisconductClick?: () => void
 }


### PR DESCRIPTION
## 📌 작업 내용

- 쪽지시험 페이지 헤더 뒤로가기 버튼 동작 연결

- 제출하기 버튼 클릭 시 결과 페이지로 이동하도록 라우팅 연결

- useNavigate import 경로를 react-router-dom으로 수정

- 결과 페이지 이동 경로를 동적 경로 생성 함수로 통일했습니다.
## 🔗 관련 이슈

- closes #72 

## 📸 스크린샷 (선택)
<img width="452" height="68" alt="image" src="https://github.com/user-attachments/assets/df7de851-13f6-4381-acdb-b54d78021ca6" />

## ✅ 체크리스트

- [ ] 코드 컨벤션 확인
- [ ] lint 에러 없음
- [ ] 빌드 정상 확인
