### PR TITLE
fix: 비밀번호 input 값 있을 때만 토글 버튼 표시

### DIFF
--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -28,18 +28,31 @@ const inputVariants = cva(
 export type InputProps = Omit<React.ComponentProps<'input'>, 'size'> &
   VariantProps<typeof inputVariants>
 
-const Input = ({ className, status, type, disabled, ...props }: InputProps) => {
+const Input = ({
+  className,
+  status,
+  type,
+  disabled,
+  onChange,
+  ...props
+}: InputProps) => {
   const [showPassword, setShowPassword] = React.useState(false)
+  const [hasValue, setHasValue] = React.useState(false)
 
   const isPassword = type === 'password'
   const currentStatus = disabled ? 'disabled' : status
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setHasValue(e.target.value.length > 0)
+    onChange?.(e)
+  }
 
   const renderRightElement = () => {
     if (currentStatus === 'success') {
       return <Check size={20} className="text-other-green" />
     }
 
-    if (isPassword) {
+    if (isPassword && hasValue) {
       return (
         <button
           type="button"
@@ -63,6 +76,7 @@ const Input = ({ className, status, type, disabled, ...props }: InputProps) => {
         <input
           type={isPassword && showPassword ? 'text' : type}
           disabled={disabled}
+          onChange={handleChange}
           className={cn(
             inputVariants({ status: currentStatus }),
             rightElement && 'pr-[48px]',


### PR DESCRIPTION
## 📌 작업 내용

- 비밀번호 input에 값이 없을 때 토글 버튼이 표시되는 문제 수정
- Input 컴포넌트에 hasValue 상태 추가
- type="password"이고 값이 있을 때만 토글 버튼 표시

**참고 사항**

- 로그인 페이지 UIUX는 추후 별도 이슈로 세밀하게 수정 예정입니다.
- 다음 작업은 회원가입 UI 구현으로 진행할 예정입니다.

## 🔗 관련 이슈

- closes #76 

## 📸 스크린샷 (선택)

## ✅ 체크리스트

- [ ] 코드 컨벤션 확인
- [ ] lint 에러 없음
- [ ] 빌드 정상 확인
