### PR TITLE
feat: 프로필 이미지 업로드 및 휴대폰 인증 기능 구현 

### DIFF
--- a/src/api/mypage.ts
+++ b/src/api/mypage.ts
@@ -8,6 +8,14 @@ import { api } from './api'
 import { APIS_PATHS } from '@/constants/apisPaths'
 import type { ChangePasswordRequest } from '@/types/api-request/myPageRequest'
 import type { ChangePasswordResponse } from '@/types/api-response/myPageResponse'
+import type {
+  ChangePhoneRequest,
+  SendPhoneVerificationCodeRequest,
+  VerifyPhoneVerificationCodeRequest,
+  ChangePhoneResponse,
+  SendPhoneVerificationCodeResponse,
+  VerifyPhoneVerificationCodeResponse,
+} from '@/types/mypage-type/verifyPhone'
 
 export const getMyInfo = async () => {
   const { data } = await api.get<MyInfoResponse>(APIS_PATHS.GET_MY_INFO)
@@ -42,6 +50,37 @@ export const postChangePassword = async (
 ): Promise<ChangePasswordResponse> => {
   const { data } = await api.post<ChangePasswordResponse>(
     APIS_PATHS.CHANGE_PASSWORD,
+    payload
+  )
+
+  return data
+}
+
+export const sendPhoneVerificationCode = async (
+  payload: SendPhoneVerificationCodeRequest
+) => {
+  const { data } = await api.post<SendPhoneVerificationCodeResponse>(
+    APIS_PATHS.PHONE_VERIFICATION_SEND,
+    payload
+  )
+
+  return data
+}
+
+export const verifyPhoneVerificationCode = async (
+  payload: VerifyPhoneVerificationCodeRequest
+) => {
+  const { data } = await api.post<VerifyPhoneVerificationCodeResponse>(
+    APIS_PATHS.PHONE_VERIFICATION_VERIFY,
+    payload
+  )
+
+  return data
+}
+
+export const changePhone = async (payload: ChangePhoneRequest) => {
+  const { data } = await api.patch<ChangePhoneResponse>(
+    APIS_PATHS.CHANGE_PHONE,
     payload
   )
 

--- a/src/api/profileImage.ts
+++ b/src/api/profileImage.ts
@@ -1,0 +1,54 @@
+import type {
+  GetProfileImagePresignedUrlRequest,
+  GetProfileImagePresignedUrlResponse,
+  PatchProfileImageRequest,
+  PatchProfileImageResponse,
+} from '@/types/mypage-type/profileImage'
+import { api } from './api'
+import { APIS_PATHS } from '@/constants/apisPaths'
+import axios from 'axios'
+
+/**
+ * Presigned URL 발급
+ */
+export async function getProfileImagePresignedUrl(
+  payload: GetProfileImagePresignedUrlRequest
+) {
+  const { data } = await api.put<GetProfileImagePresignedUrlResponse>(
+    APIS_PATHS.PRESIGNED_URL,
+    payload,
+    {
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    }
+  )
+
+  return data
+}
+
+/**
+ * S3 직접 업로드
+ */
+export async function uploadImageToAWS(params: {
+  presignedUrl: string
+  file: File
+}) {
+  await axios.put(params.presignedUrl, params.file, {
+    headers: {
+      'Content-Type': params.file.type,
+    },
+  })
+}
+
+/**
+ * 업로드된 이미지 URL 서버에 저장
+ */
+export async function patchProfileImage(payload: PatchProfileImageRequest) {
+  const { data } = await api.patch<PatchProfileImageResponse>(
+    APIS_PATHS.PROFILE_IMAGE,
+    payload
+  )
+
+  return data
+}

--- a/src/api/queries/useChangePhone.ts
+++ b/src/api/queries/useChangePhone.ts
@@ -1,0 +1,8 @@
+import { useMutation } from '@tanstack/react-query'
+import { changePhone } from '../mypage'
+
+export const useChangePhone = () => {
+  return useMutation({
+    mutationFn: changePhone,
+  })
+}

--- a/src/api/queries/usePhoneVerification.ts
+++ b/src/api/queries/usePhoneVerification.ts
@@ -1,0 +1,17 @@
+import { useMutation } from '@tanstack/react-query'
+import {
+  sendPhoneVerificationCode,
+  verifyPhoneVerificationCode,
+} from '../mypage'
+
+export const useSendPhoneVerificationCode = () => {
+  return useMutation({
+    mutationFn: sendPhoneVerificationCode,
+  })
+}
+
+export const useVerifyPhoneVerificationCode = () => {
+  return useMutation({
+    mutationFn: verifyPhoneVerificationCode,
+  })
+}

--- a/src/api/queries/useProfileImage.ts
+++ b/src/api/queries/useProfileImage.ts
@@ -1,0 +1,50 @@
+import { useMutation } from '@tanstack/react-query'
+import {
+  getProfileImagePresignedUrl,
+  patchProfileImage,
+  uploadImageToAWS,
+} from '../profileImage'
+
+export function useGetProfileImagePresignedUrl() {
+  return useMutation({
+    mutationFn: getProfileImagePresignedUrl,
+  })
+}
+
+export function usePatchProfileImage() {
+  return useMutation({
+    mutationFn: patchProfileImage,
+  })
+}
+
+/**
+ * 프로필 이미지 업로드 전체 플로우
+ * 1. presigned url 발급
+ * 2. S3 업로드
+ * 3. img_url 서버 저장
+ */
+export function useUploadProfileImage() {
+  return useMutation({
+    mutationFn: async (file: File) => {
+      const { presigned_url, img_url, key } = await getProfileImagePresignedUrl(
+        {
+          file_name: file.name,
+        }
+      )
+
+      await uploadImageToAWS({
+        presignedUrl: presigned_url,
+        file,
+      })
+
+      await patchProfileImage({
+        profile_img_url: img_url,
+      })
+
+      return {
+        img_url,
+        key,
+      }
+    },
+  })
+}

--- a/src/constants/apisPaths.ts
+++ b/src/constants/apisPaths.ts
@@ -8,4 +8,7 @@ export const APIS_PATHS = {
   GET_MY_ENROLLED_COURSES: '/accounts/me/enrolled-courses',
   AVAILABLE_COURSES: '/accounts/available-courses',
   CHANGE_PASSWORD: '/accounts/change-password',
+  PHONE_VERIFICATION_SEND: '/accounts/phone-verification/send',
+  PHONE_VERIFICATION_VERIFY: '/accounts/phone-verification/verify',
+  CHANGE_PHONE: '/accounts/change-phone',
 }

--- a/src/constants/apisPaths.ts
+++ b/src/constants/apisPaths.ts
@@ -11,4 +11,6 @@ export const APIS_PATHS = {
   PHONE_VERIFICATION_SEND: '/accounts/phone-verification/send',
   PHONE_VERIFICATION_VERIFY: '/accounts/phone-verification/verify',
   CHANGE_PHONE: '/accounts/change-phone',
+  PRESIGNED_URL: '/questions/presigned-url',
+  PROFILE_IMAGE: '/accounts/me/profile-image',
 }

--- a/src/features/mypage/MyInfoEdit.tsx
+++ b/src/features/mypage/MyInfoEdit.tsx
@@ -4,6 +4,11 @@ import { useEffect, useState } from 'react'
 import profileViewIcon from '../../assets/icons/profileViewIcon.svg'
 import cameraIcon from '../../assets/icons/cameraIcon.svg'
 import InputField from '@/components/common/InputField'
+import { useImageUpload } from '@/hooks/useImageUpload'
+import { useChangePhone } from '@/api/queries/useChangePhone'
+import { toast } from 'sonner'
+import PhoneVerifySection from './PhoneVerifySection'
+import { cn } from '@/lib/utils'
 
 type MyInfoEditProps = {
   myInfo: MyInfoResponse
@@ -20,22 +25,72 @@ export default function MyInfoEdit({
   const [name, setName] = useState('')
   const [birthday, setBirthday] = useState('')
   const [gender, setGender] = useState<'M' | 'F'>('M')
+  const [phoneNumber, setPhoneNumber] = useState(myInfo.phone_number ?? '')
+  const [verifiedPhoneToken, setVerifiedPhoneToken] = useState<string | null>(
+    null
+  )
+
+  const changePhoneMutation = useChangePhone()
 
   useEffect(() => {
     setNickname(myInfo.nickname ?? '')
     setName(myInfo.name ?? '')
     setBirthday(myInfo.birthday ?? '')
     setGender(myInfo.gender ?? 'M')
+    setPhoneNumber(myInfo.phone_number ?? '')
+    setVerifiedPhoneToken(null)
   }, [myInfo])
 
-  const handleSubmit = () => {
-    onSubmit({
-      nickname,
-      name,
-      birthday,
-      gender,
-    })
+  const handleSubmit = async () => {
+    try {
+      /**
+       * 휴대전화 번호를 변경한 경우에만 change-phone API 호출
+       * 토큰이 없으면 기존 번호 유지로 간주
+       */
+      if (verifiedPhoneToken) {
+        const result = await changePhoneMutation.mutateAsync({
+          phone_verify_token: {
+            token: verifiedPhoneToken,
+          },
+        })
+
+        setPhoneNumber(result.phone_number)
+        setVerifiedPhoneToken(null)
+      }
+
+      await onSubmit({
+        nickname,
+        name,
+        birthday,
+        gender,
+      })
+
+      toast.success('내 정보가 저장되었습니다.')
+    } catch {
+      toast.error('저장에 실패했습니다.')
+    }
   }
+
+  const { fileInputRef, preview, handleOpenFilePicker, handleChangeImage } =
+    useImageUpload({
+      initialPreview: myInfo.profile_img_url ?? null,
+      onChange: (file, previewUrl) => {
+        if (!file || !previewUrl) {
+          return
+        }
+
+        /**
+         * TODO:
+         * 백엔드 업로드 방식 확정 후 여기에 연결
+         * 1. Presigned URL 발급
+         * 2. S3 업로드
+         * 3. 저장 API 호출
+         * 또는 direct upload 방식 연결
+         * console.log('선택된 파일:', file)
+         * console.log('로컬 미리보기 URL:', previewUrl)
+         */
+      },
+    })
 
   return (
     <section className="w-186">
@@ -60,31 +115,44 @@ export default function MyInfoEdit({
         </h2>
 
         <div className="flex flex-col items-center">
-          <div className="relative mb-13 h-46 w-46 rounded-full bg-violet-100">
-            {myInfo.profile_img_url ? (
-              <img
-                src={myInfo.profile_img_url}
-                alt="프로필 이미지"
-                className="h-full w-full object-cover"
-              />
-            ) : (
-              <div>
+          <div className="relative mb-13 h-46 w-46">
+            <div className="h-full w-full overflow-hidden rounded-full bg-violet-100">
+              {preview ? (
+                <img
+                  src={preview}
+                  alt="프로필 이미지"
+                  className="h-full w-full object-cover"
+                />
+              ) : (
                 <img
                   src={profileViewIcon}
                   alt="프로필 이미지"
                   className="h-full w-full"
                 />
-              </div>
-            )}
+              )}
 
-            <button
-              type="button"
-              className="absolute right-0 bottom-0 flex h-15 w-15 cursor-pointer items-center justify-center rounded-full border border-gray-200 bg-white text-sm shadow-sm"
-            >
-              <img src={cameraIcon} alt="카메라 이미지" className="h-13 w-13" />
-            </button>
+              <button
+                type="button"
+                onClick={handleOpenFilePicker}
+                aria-label="프로필 이미지 선택"
+                className="absolute right-0 bottom-0 flex h-15 w-15 cursor-pointer items-center justify-center rounded-full border border-gray-200 bg-white text-sm shadow-sm"
+              >
+                <img
+                  src={cameraIcon}
+                  alt="카메라 이미지"
+                  className="h-13 w-13"
+                />
+              </button>
+
+              <input
+                ref={fileInputRef}
+                type="file"
+                accept="image/png,image/jpeg,image/jpg"
+                className="hidden"
+                onChange={handleChangeImage}
+              />
+            </div>
           </div>
-
           <div className="w-full space-y-10">
             <div>
               <div className="flex gap-3">
@@ -92,7 +160,7 @@ export default function MyInfoEdit({
                   id="nickname"
                   value={nickname}
                   status="default"
-                  helperText="*한글 8자, 영문 및 숫자 16자까지 혼용할 수 있어요"
+                  helperText="*한글 2자, 영문 및 숫자 10자까지 혼용할 수 있어요"
                   onChange={(e) => setNickname(e.target.value)}
                   placeholder={nickname}
                   label="닉네임"
@@ -139,28 +207,14 @@ export default function MyInfoEdit({
                 placeholder={name}
                 label="이름"
                 fieldLabelClassName="text-ui-gray-primary block text-base font-normal"
-                disabled
               />
             </div>
 
-            <div className="flex gap-3">
-              <InputField
-                id="phone_number"
-                value={myInfo.phone_number}
-                label="휴대전화"
-                fieldLabelClassName="text-ui-gray-primary block text-base font-normal"
-              />
-              <div className="flex items-end">
-                <Button
-                  type="button"
-                  variant="outline"
-                  size="sm"
-                  className="px-7 py-4"
-                >
-                  변경
-                </Button>
-              </div>
-            </div>
+            <PhoneVerifySection
+              phoneNumber={phoneNumber}
+              onChangePhoneNumber={setPhoneNumber}
+              onVerifiedTokenChange={setVerifiedPhoneToken}
+            />
 
             <div>
               <p className="text-ui-gray-primary mb-2 block text-base font-normal">
@@ -171,25 +225,25 @@ export default function MyInfoEdit({
                 <button
                   type="button"
                   onClick={() => setGender('M')}
-                  disabled
-                  className={`flex h-10.5 min-w-20 items-center justify-center rounded-[100px] border px-7 py-4 text-base font-semibold ${
+                  className={cn(
+                    `flex h-10.5 min-w-20 cursor-pointer items-center justify-center rounded-full border px-7 py-4 text-base font-semibold`,
                     gender === 'M'
                       ? 'border-primary-default bg-primary-100 text-primary-default'
                       : 'bg-ui-gray-200 border-ui-gray-250 text-ui-gray-600'
-                  }`}
+                  )}
                 >
                   남
                 </button>
 
                 <button
                   type="button"
-                  disabled
                   onClick={() => setGender('F')}
-                  className={`flex h-10.5 min-w-20 items-center justify-center rounded-full border px-7 py-4 text-base font-semibold ${
+                  className={cn(
+                    'flex h-10.5 min-w-20 cursor-pointer items-center justify-center rounded-full border px-7 py-4 text-base font-semibold',
                     gender === 'F'
                       ? 'border-violet-500 bg-violet-50 text-violet-600'
                       : 'bg-ui-gray-200 border-ui-gray-250 text-ui-gray-600'
-                  }`}
+                  )}
                 >
                   여
                 </button>
@@ -202,7 +256,6 @@ export default function MyInfoEdit({
               onChange={(e) => setBirthday(e.target.value)}
               placeholder={birthday}
               label="생년월일"
-              disabled
               fieldLabelClassName="text-ui-gray-primary block text-base font-normal"
             />
           </div>

--- a/src/features/mypage/MyInfoEdit.tsx
+++ b/src/features/mypage/MyInfoEdit.tsx
@@ -9,11 +9,12 @@ import { useChangePhone } from '@/api/queries/useChangePhone'
 import { toast } from 'sonner'
 import PhoneVerifySection from './PhoneVerifySection'
 import { cn } from '@/lib/utils'
+import { useUploadProfileImage } from '@/api/queries/useProfileImage'
 
 type MyInfoEditProps = {
   myInfo: MyInfoResponse
   isPending: boolean
-  onSubmit: (payload: UpdateMyInfoRequest) => void
+  onSubmit: (payload: UpdateMyInfoRequest) => Promise<void> | void
 }
 
 export default function MyInfoEdit({
@@ -31,6 +32,7 @@ export default function MyInfoEdit({
   )
 
   const changePhoneMutation = useChangePhone()
+  const uploadProfileImageMutation = useUploadProfileImage()
 
   useEffect(() => {
     setNickname(myInfo.nickname ?? '')
@@ -74,9 +76,16 @@ export default function MyInfoEdit({
   const { fileInputRef, preview, handleOpenFilePicker, handleChangeImage } =
     useImageUpload({
       initialPreview: myInfo.profile_img_url ?? null,
-      onChange: (file, previewUrl) => {
-        if (!file || !previewUrl) {
+      onChange: async (file) => {
+        if (!file) {
           return
+        }
+
+        try {
+          await uploadProfileImageMutation.mutateAsync(file)
+          toast.success('프로필 사진이 등록되었습니다.')
+        } catch {
+          toast.error('프로필 사진 업로드에 실패했습니다.')
         }
 
         /**
@@ -91,6 +100,10 @@ export default function MyInfoEdit({
          */
       },
     })
+  const isSubmitDisabled =
+    isPending ||
+    changePhoneMutation.isPending ||
+    uploadProfileImageMutation.isPending
 
   return (
     <section className="w-186">
@@ -101,11 +114,13 @@ export default function MyInfoEdit({
           type="button"
           variant="fill"
           size="md"
-          disabled={isPending}
+          disabled={isSubmitDisabled}
           onClick={handleSubmit}
           className="h-12 w-32 rounded-lg px-9 py-5 text-base font-semibold"
         >
-          {isPending ? '저장중...' : '저장하기'}
+          {isPending || changePhoneMutation.isPending
+            ? '저장중...'
+            : '저장하기'}
         </Button>
       </div>
 
@@ -135,6 +150,7 @@ export default function MyInfoEdit({
                 type="button"
                 onClick={handleOpenFilePicker}
                 aria-label="프로필 이미지 선택"
+                disabled={uploadProfileImageMutation.isPending}
                 className="absolute right-0 bottom-0 flex h-15 w-15 cursor-pointer items-center justify-center rounded-full border border-gray-200 bg-white text-sm shadow-sm"
               >
                 <img

--- a/src/features/mypage/PhoneVerifySection.tsx
+++ b/src/features/mypage/PhoneVerifySection.tsx
@@ -1,0 +1,115 @@
+import InputField from '@/components/common/InputField'
+import Button from '@/components/ui/button'
+import usePhoneNumberVerificationSection from '@/hooks/usePhoneVerifySection'
+
+type PhoneVerifySectionProps = {
+  phoneNumber: string
+  onChangePhoneNumber: (phoneNumber: string) => void
+  onVerifiedTokenChange: (token: string | null) => void
+}
+
+export default function PhoneVerifySection({
+  phoneNumber,
+  onChangePhoneNumber,
+  onVerifiedTokenChange,
+}: PhoneVerifySectionProps) {
+  const {
+    phoneInputRef,
+    phoneDisplayValue,
+    phoneButtonText,
+    verificationStatus,
+    code,
+    formattedTime,
+    isCodeSent,
+    isCodeVerified,
+    isExpired,
+    isPhoneReadOnly,
+    showVerificationField,
+    verificationHelperText,
+    isVerifyButtonDisabled,
+    isPhoneActionButtonDisabled,
+    sendCodeMutation,
+    verifyCodeMutation,
+    handlePhoneNumberChange,
+    handleCodeChange,
+    handleClickPhoneActionButton,
+    handleVerifyCode,
+  } = usePhoneNumberVerificationSection({
+    phoneNumber,
+    onChangePhoneNumber,
+    onVerifiedTokenChange,
+  })
+
+  return (
+    <div className="space-y-4">
+      <div className="flex gap-3">
+        <InputField
+          id="phone_number"
+          value={phoneDisplayValue}
+          onChange={(e) => handlePhoneNumberChange(e.target.value)}
+          label="휴대전화"
+          readOnly={isPhoneReadOnly}
+          status="default"
+          ref={phoneInputRef}
+          fieldLabelClassName="text-ui-gray-primary block text-base font-normal"
+        />
+
+        <div className="flex items-end">
+          <Button
+            type="button"
+            variant="outline"
+            size={phoneButtonText === '인증번호 받기' ? 'md' : 'sm'}
+            className="rounded-lg px-7 py-4"
+            onClick={handleClickPhoneActionButton}
+            disabled={isPhoneActionButtonDisabled}
+          >
+            {sendCodeMutation.isPending ? '전송중...' : phoneButtonText}
+          </Button>
+        </div>
+      </div>
+
+      {showVerificationField && (
+        <div className="space-y-1">
+          <div className="flex gap-3">
+            <div className="relative flex-1">
+              <InputField
+                id="verification_code"
+                value={code}
+                onChange={(e) => handleCodeChange(e.target.value)}
+                placeholder="인증번호 입력"
+                readOnly={isCodeVerified}
+                status={verificationStatus}
+                fieldLabelClassName="text-ui-gray-primary block text-base font-normal"
+              />
+
+              {!isCodeVerified && isCodeSent && !isExpired && (
+                <span className="text-other-red pointer-events-none absolute top-4 right-4 text-sm font-medium">
+                  {formattedTime}
+                </span>
+              )}
+            </div>
+
+            <div className="flex items-end">
+              <Button
+                type="button"
+                variant="outline"
+                size="md"
+                className="border-grey-10 rounded-lg border px-7 py-4"
+                onClick={handleVerifyCode}
+                disabled={isVerifyButtonDisabled}
+              >
+                {verifyCodeMutation.isPending ? '확인중...' : '인증번호 확인'}
+              </Button>
+            </div>
+          </div>
+
+          {verificationHelperText && (
+            <p className="text-other-red text-xs font-normal">
+              {verificationHelperText}
+            </p>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/hooks/useImageUpload.ts
+++ b/src/hooks/useImageUpload.ts
@@ -1,0 +1,113 @@
+import { useEffect, useRef, useState } from 'react'
+import { toast } from 'sonner'
+
+type UseImageUploadParams = {
+  initialPreview?: string | null
+  allowedTypes?: string[]
+  maxSizeInBytes?: number
+  onChange?: (
+    file: File | null,
+    previewUrl: string | null
+  ) => Promise<void> | void
+}
+
+const DEFAULT_ALLOWED_TYPES = ['image/jpeg', 'image/png', 'image/jpg']
+const DEFAULT_MAX_SIZE = 5 * 1024 * 1024
+
+/**
+ * 이미지 업로드 훅
+ * - 파일 유효성 검사
+ * - 로컬 미리보기 생성
+ * - 실제 업로드 로직은 바깥에서 처리
+ */
+export function useImageUpload({
+  initialPreview = null,
+  allowedTypes = DEFAULT_ALLOWED_TYPES,
+  maxSizeInBytes = DEFAULT_MAX_SIZE,
+  onChange,
+}: UseImageUploadParams) {
+  const fileInputRef = useRef<HTMLInputElement>(null)
+  const [preview, setPreview] = useState<string | null>(initialPreview)
+  const [fileName, setFileName] = useState('')
+
+  useEffect(() => {
+    setPreview((prev) => {
+      if (prev?.startsWith('blob:')) {
+        return prev
+      }
+      return initialPreview
+    })
+  }, [initialPreview])
+
+  useEffect(() => {
+    return () => {
+      if (preview?.startsWith('blob:')) {
+        URL.revokeObjectURL(preview)
+      }
+    }
+  }, [preview])
+
+  const handleOpenFilePicker = () => {
+    fileInputRef.current?.click()
+  }
+
+  const clearImage = () => {
+    setPreview((prev) => {
+      if (prev?.startsWith('blob:')) {
+        URL.revokeObjectURL(prev)
+      }
+      return null
+    })
+    setFileName('')
+
+    if (fileInputRef.current) {
+      fileInputRef.current.value = ''
+    }
+
+    onChange?.(null, null)
+  }
+
+  const handleChangeImage = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0]
+
+    if (!file) {
+      return
+    }
+
+    if (!allowedTypes.includes(file.type)) {
+      toast.error('jpg, jpeg, png 형식의 이미지 파일만 업로드할 수 있습니다.')
+      e.target.value = ''
+      return
+    }
+
+    if (file.size > maxSizeInBytes) {
+      toast.error('이미지 파일은 5MB 이하만 업로드할 수 있습니다.')
+      e.target.value = ''
+      return
+    }
+
+    const nextPreview = URL.createObjectURL(file)
+
+    setPreview((prev) => {
+      if (prev?.startsWith('blob:')) {
+        URL.revokeObjectURL(prev)
+      }
+      return nextPreview
+    })
+
+    setFileName(file.name)
+    onChange?.(file, nextPreview)
+
+    e.target.value = ''
+  }
+
+  return {
+    fileInputRef,
+    preview,
+    fileName,
+    handleOpenFilePicker,
+    handleChangeImage,
+    clearImage,
+    setPreview,
+  }
+}

--- a/src/hooks/usePhoneVerification.ts
+++ b/src/hooks/usePhoneVerification.ts
@@ -101,5 +101,6 @@ export const usePhoneVerification = () => {
     setVerificationError,
     validateBeforeVerify,
     validateBeforeSubmit,
+    isExpired,
   }
 }

--- a/src/hooks/usePhoneVerifySection.ts
+++ b/src/hooks/usePhoneVerifySection.ts
@@ -1,0 +1,212 @@
+import { useEffect, useRef, useState } from 'react'
+import { toast } from 'sonner'
+
+import {
+  useSendPhoneVerificationCode,
+  useVerifyPhoneVerificationCode,
+} from '@/api/queries/usePhoneVerification'
+import { usePhoneVerification } from '@/hooks/usePhoneVerification'
+import { formatPhoneNumber } from '@/utils/formatPhoneNumber'
+import getPhoneButtonText, { type PhoneEditStep } from '@/utils/phoneButtonText'
+
+type VerificationStatus = 'default' | 'success' | 'danger'
+
+type UsePhoneNumberVerificationSectionParams = {
+  phoneNumber: string
+  onChangePhoneNumber: (phoneNumber: string) => void
+  onVerifiedTokenChange: (token: string | null) => void
+}
+
+export default function usePhoneNumberVerificationSection({
+  phoneNumber,
+  onChangePhoneNumber,
+  onVerifiedTokenChange,
+}: UsePhoneNumberVerificationSectionParams) {
+  const [phoneEditStep, setPhoneEditStep] = useState<PhoneEditStep>('default')
+  const [verificationStatus, setVerificationStatus] =
+    useState<VerificationStatus>('default')
+
+  const phoneInputRef = useRef<HTMLInputElement | null>(null)
+
+  const sendCodeMutation = useSendPhoneVerificationCode()
+  const verifyCodeMutation = useVerifyPhoneVerificationCode()
+
+  const {
+    code,
+    isCodeSent,
+    isCodeVerified,
+    codeErrorMessage,
+    formattedTime,
+    isExpired,
+    handleCodeChange,
+    resetVerification,
+    markCodeSent,
+    markCodeVerified,
+    setVerificationError,
+    validateBeforeVerify,
+  } = usePhoneVerification()
+
+  useEffect(() => {
+    if (phoneEditStep === 'verifying' && isExpired && !isCodeVerified) {
+      setVerificationStatus('danger')
+      setVerificationError(
+        '인증번호 전송 시간이 초과되었습니다. 인증번호를 재전송 해주세요.'
+      )
+    }
+  }, [phoneEditStep, isExpired, isCodeVerified, setVerificationError])
+
+  const phoneDisplayValue = formatPhoneNumber(phoneNumber)
+  const phoneButtonText = getPhoneButtonText(phoneEditStep)
+
+  const isPhoneReadOnly =
+    phoneEditStep === 'default' || phoneEditStep === 'verified'
+
+  const showVerificationField =
+    phoneEditStep === 'verifying' || phoneEditStep === 'verified'
+
+  const verificationHelperText =
+    verificationStatus === 'success' ? undefined : codeErrorMessage || undefined
+
+  const isVerifyButtonDisabled =
+    !isCodeSent ||
+    !code.trim() ||
+    isCodeVerified ||
+    isExpired ||
+    verifyCodeMutation.isPending
+
+  const isPhoneActionButtonDisabled =
+    phoneEditStep === 'verified' || sendCodeMutation.isPending
+
+  const focusPhoneInput = () => {
+    requestAnimationFrame(() => {
+      phoneInputRef.current?.focus()
+    })
+  }
+
+  const resetPhoneVerificationUi = () => {
+    setVerificationStatus('default')
+    resetVerification()
+    onVerifiedTokenChange(null)
+  }
+
+  const enterEditMode = () => {
+    setPhoneEditStep('editing')
+    resetPhoneVerificationUi()
+    focusPhoneInput()
+  }
+
+  const validatePhoneNumberBeforeSend = () => {
+    if (!phoneNumber.trim()) {
+      setVerificationStatus('danger')
+      setVerificationError('휴대전화 번호를 입력해주세요.')
+      focusPhoneInput()
+      return false
+    }
+
+    if (phoneNumber.length !== 11) {
+      setVerificationStatus('danger')
+      setVerificationError('휴대전화 번호 11자리를 입력해주세요.')
+      focusPhoneInput()
+      return false
+    }
+
+    return true
+  }
+
+  const handlePhoneNumberChange = (value: string) => {
+    const onlyNumbers = value.replace(/\D/g, '').slice(0, 11)
+
+    onChangePhoneNumber(onlyNumbers)
+    onVerifiedTokenChange(null)
+
+    if (phoneEditStep === 'verified') {
+      setPhoneEditStep('editing')
+    }
+
+    if (verificationStatus !== 'default') {
+      setVerificationStatus('default')
+    }
+
+    if (isCodeSent || isCodeVerified) {
+      resetVerification()
+    }
+  }
+
+  const handleSendVerificationCode = async () => {
+    const isValid = validatePhoneNumberBeforeSend()
+
+    if (!isValid) return
+
+    try {
+      await sendCodeMutation.mutateAsync({
+        phone_number: phoneNumber,
+      })
+
+      markCodeSent()
+      setPhoneEditStep('verifying')
+      setVerificationStatus('default')
+      toast.success('인증번호를 전송했습니다.')
+    } catch {
+      setVerificationStatus('danger')
+      setVerificationError('인증번호 전송에 실패했습니다.')
+    }
+  }
+
+  const handleClickPhoneActionButton = async () => {
+    if (phoneEditStep === 'default' || phoneEditStep === 'verified') {
+      enterEditMode()
+      return
+    }
+
+    await handleSendVerificationCode()
+  }
+
+  const handleVerifyCode = async () => {
+    const isValid = validateBeforeVerify()
+
+    if (!isValid) {
+      setVerificationStatus('danger')
+      return
+    }
+
+    try {
+      const result = await verifyCodeMutation.mutateAsync({
+        phone_number: phoneNumber,
+        code,
+      })
+
+      markCodeVerified()
+      setPhoneEditStep('verified')
+      setVerificationStatus('success')
+      onVerifiedTokenChange(result.token)
+      toast.success('휴대전화 인증이 완료되었습니다.')
+    } catch {
+      setVerificationStatus('danger')
+      setVerificationError('인증번호가 일치하지 않습니다.')
+    }
+  }
+
+  return {
+    phoneInputRef,
+    phoneDisplayValue,
+    phoneButtonText,
+    phoneEditStep,
+    verificationStatus,
+    code,
+    formattedTime,
+    isCodeSent,
+    isCodeVerified,
+    isExpired,
+    isPhoneReadOnly,
+    showVerificationField,
+    verificationHelperText,
+    isVerifyButtonDisabled,
+    isPhoneActionButtonDisabled,
+    sendCodeMutation,
+    verifyCodeMutation,
+    handlePhoneNumberChange,
+    handleCodeChange,
+    handleClickPhoneActionButton,
+    handleVerifyCode,
+  }
+}

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -1,5 +1,6 @@
 import { availableCoursesHandlers } from './handlers/availableCoursesHandlers'
 import { changePasswordHandlers } from './handlers/changePasswordHandlers'
+import { changePhoneHandlers } from './handlers/changePhoneHandlers'
 import { examHandlers } from './handlers/examHandlers'
 import { mypageHandlers } from './handlers/myPageHandlers'
 
@@ -8,4 +9,5 @@ export const handlers = [
   ...mypageHandlers,
   ...availableCoursesHandlers,
   ...changePasswordHandlers,
+  ...changePhoneHandlers,
 ]

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -3,6 +3,7 @@ import { changePasswordHandlers } from './handlers/changePasswordHandlers'
 import { changePhoneHandlers } from './handlers/changePhoneHandlers'
 import { examHandlers } from './handlers/examHandlers'
 import { mypageHandlers } from './handlers/myPageHandlers'
+import { profileImageHandlers } from './handlers/profileImageHandlers'
 
 export const handlers = [
   ...examHandlers,
@@ -10,4 +11,5 @@ export const handlers = [
   ...availableCoursesHandlers,
   ...changePasswordHandlers,
   ...changePhoneHandlers,
+  ...profileImageHandlers,
 ]

--- a/src/mocks/handlers/changePhoneHandlers.ts
+++ b/src/mocks/handlers/changePhoneHandlers.ts
@@ -1,0 +1,125 @@
+import { http, HttpResponse } from 'msw'
+
+type VerifyRequestBody = {
+  phone_number: string
+  code: string
+}
+
+type SendRequestBody = {
+  phone_number: string
+}
+
+type ChangePhoneRequestBody = {
+  phone_verify_token: {
+    token: string
+  }
+}
+
+export const changePhoneHandlers = [
+  http.post('/api/v1/accounts/phone-verification/send', async ({ request }) => {
+    const body = (await request.json()) as SendRequestBody
+
+    if (!body.phone_number || body.phone_number.length !== 11) {
+      return HttpResponse.json(
+        {
+          error_detail: {
+            phone_number: ['휴대전화 번호는 11자리여야 합니다.'],
+          },
+        },
+        { status: 400 }
+      )
+    }
+
+    return HttpResponse.json(
+      {
+        detail: '인증번호가 전송되었습니다.',
+      },
+      { status: 200 }
+    )
+  }),
+
+  http.post(
+    '/api/v1/accounts/phone-verification/verify',
+    async ({ request }) => {
+      const body = (await request.json()) as VerifyRequestBody
+
+      if (!body.phone_number || !body.code) {
+        return HttpResponse.json(
+          {
+            error_detail: '잘못된 요청입니다.',
+          },
+          { status: 400 }
+        )
+      }
+
+      if (body.code !== '123123') {
+        return HttpResponse.json(
+          {
+            error_detail: '인증번호가 유효하지 않습니다.',
+          },
+          { status: 401 }
+        )
+      }
+
+      return HttpResponse.json(
+        {
+          detail: '휴대전화 인증에 성공했습니다.',
+          token: '123456',
+        },
+        { status: 200 }
+      )
+    }
+  ),
+
+  http.patch('/api/v1/accounts/change-phone', async ({ request }) => {
+    const body = (await request.json()) as ChangePhoneRequestBody
+
+    const token = body.phone_verify_token?.token
+
+    if (!token) {
+      return HttpResponse.json(
+        {
+          error_detail: {
+            phone_number: ['이 필드는 필수 항목입니다.'],
+          },
+        },
+        { status: 400 }
+      )
+    }
+
+    if (token === 'expired-token') {
+      return HttpResponse.json(
+        {
+          error_detail: '자격 인증 데이터가 제공되지 않았습니다.',
+        },
+        { status: 401 }
+      )
+    }
+
+    if (token === 'duplicated-phone-token') {
+      return HttpResponse.json(
+        {
+          error_detail: '이미 등록된 휴대폰 번호입니다.',
+        },
+        { status: 409 }
+      )
+    }
+
+    if (token !== '123dsd123uhnxxzf456') {
+      return HttpResponse.json(
+        {
+          error_detail: '휴대폰 인증 실패 - 인증토크가 유효하지 않습니다.',
+        },
+        { status: 401 }
+      )
+    }
+
+    return HttpResponse.json(
+      {
+        detail: '휴대폰 번호 변경에 성공하였습니다.',
+        phone_number: '01011112222',
+      },
+      { status: 200 }
+    )
+  }),
+]

--- a/src/mocks/handlers/profileImageHandlers.ts
+++ b/src/mocks/handlers/profileImageHandlers.ts
@@ -1,0 +1,82 @@
+import { http, HttpResponse } from 'msw'
+
+const MOCK_PRESIGNED_URL =
+  'https://mock-s3.ap-northeast-2.amazonaws.com/uploads/images/profiles/mock-profile.png?AWSAccessKeyId=mock&Signature=mock'
+
+const MOCK_IMG_URL =
+  'https://mock-s3.ap-northeast-2.amazonaws.com/uploads/images/profiles/mock-profile.png'
+
+export const profileImageHandlers = [
+  /**
+   * Presigned URL 발급
+   */
+  http.put('/api/v1/questions/presigned-url', async ({ request }) => {
+    const body = (await request.json()) as {
+      file_name?: string
+    }
+
+    if (!body.file_name) {
+      return HttpResponse.json(
+        {
+          error_detail: {
+            file_name: ['이 필드는 필수 항목입니다.'],
+          },
+        },
+        { status: 400 }
+      )
+    }
+
+    const fileName = body.file_name.toLowerCase()
+    const isSupportedFile =
+      fileName.endsWith('.png') ||
+      fileName.endsWith('.jpg') ||
+      fileName.endsWith('.jpeg')
+
+    if (!isSupportedFile) {
+      return HttpResponse.json(
+        {
+          error_detail: '지원하지 않는 파일 형식입니다.',
+        },
+        { status: 400 }
+      )
+    }
+
+    return HttpResponse.json({
+      presigned_url: MOCK_PRESIGNED_URL,
+      img_url: MOCK_IMG_URL,
+      key: 'uploads/images/profiles/mock-profile.png',
+    })
+  }),
+
+  /**
+   * S3 업로드 mock
+   * presigned url 전체 문자열 매칭이 까다로우니 와일드카드로 받음
+   */
+  http.put('https://mock-s3.ap-northeast-2.amazonaws.com/*', async () => {
+    return new HttpResponse(null, { status: 200 })
+  }),
+
+  /**
+   * 프로필 이미지 저장
+   */
+  http.patch('/api/v1/accounts/me/profile-image', async ({ request }) => {
+    const body = (await request.json()) as {
+      profile_img_url?: string
+    }
+
+    if (!body.profile_img_url) {
+      return HttpResponse.json(
+        {
+          error_detail: {
+            profile_img_url: ['이 필드는 필수 항목입니다.'],
+          },
+        },
+        { status: 400 }
+      )
+    }
+
+    return HttpResponse.json({
+      detail: '프로필 사진이 등록되었습니다.',
+    })
+  }),
+]

--- a/src/types/mypage-type/profileImage.ts
+++ b/src/types/mypage-type/profileImage.ts
@@ -1,0 +1,17 @@
+export type GetProfileImagePresignedUrlRequest = {
+  file_name: string
+}
+
+export type GetProfileImagePresignedUrlResponse = {
+  presigned_url: string
+  img_url: string
+  key: string
+}
+
+export type PatchProfileImageRequest = {
+  profile_img_url: string
+}
+
+export type PatchProfileImageResponse = {
+  detail: string
+}

--- a/src/types/mypage-type/verifyPhone.ts
+++ b/src/types/mypage-type/verifyPhone.ts
@@ -1,0 +1,28 @@
+export type SendPhoneVerificationCodeRequest = {
+  phone_number: string
+}
+
+export type SendPhoneVerificationCodeResponse = {
+  detail: string
+}
+
+export type VerifyPhoneVerificationCodeRequest = {
+  phone_number: string
+  code: string
+}
+
+export type VerifyPhoneVerificationCodeResponse = {
+  detail: string
+  token: string
+}
+
+export type ChangePhoneRequest = {
+  phone_verify_token: {
+    token: string
+  }
+}
+
+export type ChangePhoneResponse = {
+  detail: string
+  phone_number: string
+}

--- a/src/utils/formatPhoneNumber.ts
+++ b/src/utils/formatPhoneNumber.ts
@@ -1,0 +1,17 @@
+export const formatPhoneNumber = (value: string) => {
+  const numbers = value.replace(/\D/g, '').slice(0, 11)
+
+  if (numbers.length <= 3) {
+    return numbers
+  }
+
+  if (numbers.length <= 7) {
+    return `${numbers.slice(0, 3)}-${numbers.slice(3)}`
+  }
+
+  return `${numbers.slice(0, 3)}-${numbers.slice(3, 7)}-${numbers.slice(7)}`
+}
+
+export const normalizePhoneNumber = (value: string) => {
+  return value.replace(/\D/g, '').slice(0, 11)
+}

--- a/src/utils/phoneButtonText.ts
+++ b/src/utils/phoneButtonText.ts
@@ -1,0 +1,16 @@
+export type PhoneEditStep = 'default' | 'editing' | 'verifying' | 'verified'
+
+export default function getPhoneButtonText(step: PhoneEditStep) {
+  switch (step) {
+    case 'default':
+      return '변경'
+    case 'editing':
+      return '인증번호 받기'
+    case 'verifying':
+      return '재전송'
+    case 'verified':
+      return '재전송'
+    default:
+      return '변경'
+  }
+}


### PR DESCRIPTION
## 📌 작업 내용

휴대폰 인증 및 번호 변경 API 연동 및 MSW 추가
- 휴대폰 인증번호 전송/검증/번호 변경 API 함수 추가
- 휴대폰 인증 및 번호 변경용 Tanstack Query mutation 훅 구현
- 관련 API 경로 상수와 요청/응답 타입 정의
- MSW 휴대폰 인증/번호 변경 핸들러 및 예외 응답 목업 등록

내 정보 수정 화면에 휴대폰 인증 섹션 추가
- 내 정보 수정 화면에 휴대폰 번호 변경 및 인증 UI 연동
- 휴대폰 인증 전용 섹션 컴포넌트와 상태 관리 훅 구현
- 인증번호 전송/확인 단계별 버튼 상태 및 만료 처리 추가
- 휴대폰 번호 포맷팅 및 버튼 문구 유틸 함수 추가

프로필 이미지 업로드 API 및 목 핸들러 추가
- Presigned URL 발급, S3 업로드, 프로필 이미지 저장 API 추가
- 프로필 이미지 업로드 전용 Tanstack Query mutation 훅 구현
- 프로필 이미지 업로드 관련 요청/응답 타입과 엔드포인트 정의
- MSW 프로필 이미지 업로드 핸들러 등록

프로필 이미지 업로드 훅 및 내 정보 수정 연동 추가
- 이미지 파일 선택, 유효성 검사, 미리보기 처리를 위한 업로드 훅 추가
- 내 정보 수정 화면에 프로필 이미지 업로드 mutation 연동
- 프로필 이미지 업로드 성공/실패 토스트 처리 추가

## 🔗 관련 이슈

- closes #68 

## 📸 스크린샷 (선택)
<img width="684" height="176" alt="스크린샷 2026-03-18 오후 11 11 55" src="https://github.com/user-attachments/assets/d89ab4c8-9b80-4b24-b451-9a747925ddf4" />

<img width="684" height="176" alt="스크린샷 2026-03-18 오후 11 12 03" src="https://github.com/user-attachments/assets/36302141-8195-4c77-a714-d2866b8ee399" />

<img width="695" height="458" alt="스크린샷 2026-03-18 오후 11 12 39" src="https://github.com/user-attachments/assets/e7d8bf99-e2c2-42c4-9776-d3e2220d04a5" />

## ✅ 체크리스트

- [ ] 코드 컨벤션 확인
- [ ] lint 에러 없음
- [ ] 빌드 정상 확인
