### PR TITLE
fix: 헤더 링크와 유저 메뉴 동작 개선

### DIFF
--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -1,6 +1,7 @@
 import { Link } from 'react-router'
 import Logo from '@/assets/images/logo.png'
 import UserMenu from '@/features/mypage/UserMenu'
+import { ROUTES_PATHS } from '@/constants/routesPaths'
 
 function Header() {
   return (
@@ -9,14 +10,16 @@ function Header() {
         🚨 선착순 모집! 국비지원 받고 4주 완성
       </section>
 
-      <section className="text-ui-gray-600 flex h-16 w-full items-center justify-between px-90 text-[18px] whitespace-nowrap">
+      <section className="text-ui-gray-600 flex h-16 w-full min-w-170 items-center justify-between px-10 text-[18px] whitespace-nowrap md:px-20 xl:px-90">
         <div className="flex items-center gap-15">
           <h1 className="shrink-0">
-            <img
-              className="h-auto w-[120px] object-contain"
-              src={Logo}
-              alt="logo"
-            />
+            <Link to="/">
+              <img
+                className="h-auto w-30 object-contain"
+                src={Logo}
+                alt="logo"
+              />
+            </Link>
           </h1>
 
           <nav aria-label="주요 메뉴">
@@ -36,11 +39,11 @@ function Header() {
             {/* TODO: 로그인 여부에 따른 분기처리 예정 */}
             <UserMenu />
             <li className="py-4">
-              <Link to="/login">로그인</Link>
+              <Link to={ROUTES_PATHS.LOGIN_PAGE}>로그인</Link>
             </li>
             <li className="text-xl">|</li>
             <li className="py-4">
-              <Link to="/signup">회원가입</Link>
+              <Link to={ROUTES_PATHS.SIGNUP_PAGE}>회원가입</Link>
             </li>
           </ul>
         </nav>

--- a/src/features/mypage/UserMenu.tsx
+++ b/src/features/mypage/UserMenu.tsx
@@ -50,7 +50,7 @@ export default function UserMenu() {
         </button>
 
         {showUserMenu && (
-          <div className="absolute left-0 mt-6 flex -translate-x-3/4 flex-col rounded-2xl border border-gray-200 bg-white px-4 py-6 shadow-lg">
+          <div className="absolute left-40 mt-6 flex -translate-x-3/4 flex-col rounded-2xl border border-gray-200 bg-white px-4 py-6 shadow-lg">
             <div className="mb-5">
               <span className="text-ui-gray-primary block text-xl font-bold">
                 {/* TODO: 유저 닉네임 */}
@@ -75,7 +75,10 @@ export default function UserMenu() {
             >
               수강생 등록
             </Button>
-            <Link to={ROUTES_PATHS.MY_PAGE}>
+            <Link
+              to={ROUTES_PATHS.MY_PAGE}
+              onClick={() => setShowUserMenu(false)}
+            >
               <Button
                 type="button"
                 variant="sidebarTab"
@@ -94,6 +97,7 @@ export default function UserMenu() {
               variant="sidebarTab"
               size="sidebarTab"
               className="w-full rounded-none px-2 py-2.5 text-sm font-normal"
+              onClick={() => setShowUserMenu(false)}
             >
               로그아웃
             </Button>

--- a/src/features/mypage/student-register/CourseRegisterModal.tsx
+++ b/src/features/mypage/student-register/CourseRegisterModal.tsx
@@ -3,6 +3,7 @@ import Button from '@/components/ui/button'
 import Modal from '@/components/ui/modal/Modal'
 import type { SelectedCourseRegisterValue } from '@/types/api-response/course'
 import CourseRegisterFields from './CourseRegisterFields'
+import { cn } from '@/lib/utils'
 
 type CourseRegisterModalProps = {
   isOpen: boolean
@@ -22,6 +23,8 @@ export default function CourseRegisterModal({
   onChange,
   onImageError,
 }: CourseRegisterModalProps) {
+  const isSubmitDisabled = !value.courseId || !value.cohortId
+
   return (
     <Modal isOpen={isOpen} onClose={onClose}>
       <div className="w-99 p-6">
@@ -52,8 +55,12 @@ export default function CourseRegisterModal({
           type="button"
           variant="fill"
           size="full"
-          className="h-13 rounded-lg p-2 text-base font-normal"
+          className={cn(
+            `h-13 rounded-lg p-2 text-base font-normal`,
+            isSubmitDisabled ? 'cursor-not-allowed' : ''
+          )}
           onClick={onClose}
+          disabled={isSubmitDisabled}
         >
           등록하기
         </Button>


### PR DESCRIPTION
## 📌 작업 내용

- 로그인, 회원가입 링크를 라우트 상수로 정리
- 헤더 레이아웃 반응형 여백 및 최소 너비 보정
- 유저 메뉴 위치 조정 및 메뉴 클릭 시 드롭다운 닫힘 처리
- 수강생 등록 모달에서 과정/기수 미선택 시 등록 버튼 비활성화

## 🔗 관련 이슈

- closes #82 

## 📸 스크린샷 (선택)

## ✅ 체크리스트

- [ ] 코드 컨벤션 확인
- [ ] lint 에러 없음
- [ ] 빌드 정상 확인
