### PR TITLE
feat: 닉네임 중복 확인 UI 및 검증 로직 추가

### DIFF
--- a/src/api/checkNickName.ts
+++ b/src/api/checkNickName.ts
@@ -1,0 +1,17 @@
+import type {
+  CheckNicknameRequest,
+  CheckNicknameSuccessResponse,
+} from '@/types/checkNickName'
+import { api } from './api'
+import { APIS_PATHS } from '@/constants/apisPaths'
+
+export const postCheckNickname = async (
+  payload: CheckNicknameRequest
+): Promise<CheckNicknameSuccessResponse> => {
+  const { data } = await api.post<CheckNicknameSuccessResponse>(
+    APIS_PATHS.CHECK_NICKNAME,
+    payload
+  )
+
+  return data
+}

--- a/src/api/queries/useCheckNickName.ts
+++ b/src/api/queries/useCheckNickName.ts
@@ -1,0 +1,18 @@
+import type {
+  CheckNicknameErrorResponse,
+  CheckNicknameRequest,
+  CheckNicknameSuccessResponse,
+} from '@/types/checkNickName'
+import { useMutation } from '@tanstack/react-query'
+import { AxiosError } from 'axios'
+import { postCheckNickname } from '../checkNickName'
+
+export const useCheckNickName = () => {
+  return useMutation<
+    CheckNicknameSuccessResponse,
+    AxiosError<CheckNicknameErrorResponse>,
+    CheckNicknameRequest
+  >({
+    mutationFn: postCheckNickname,
+  })
+}

--- a/src/constants/apisPaths.ts
+++ b/src/constants/apisPaths.ts
@@ -13,4 +13,5 @@ export const APIS_PATHS = {
   CHANGE_PHONE: '/accounts/change-phone',
   PRESIGNED_URL: '/questions/presigned-url',
   PROFILE_IMAGE: '/accounts/me/profile-image',
+  CHECK_NICKNAME: '/accounts/check-nickname',
 }

--- a/src/constants/nickNameHelperText.ts
+++ b/src/constants/nickNameHelperText.ts
@@ -1,0 +1,5 @@
+export const NICKNAME_HELPTER_TEXT = {
+  default: '*한글 2자, 영문 및 숫자 10자까지 혼용할 수 있어요',
+  empty: '닉네임을 입력해주세요.',
+  danger: '닉네임 중복확인에 실패했습니다.',
+}

--- a/src/features/mypage/MyInfoEdit.tsx
+++ b/src/features/mypage/MyInfoEdit.tsx
@@ -10,6 +10,7 @@ import { toast } from 'sonner'
 import PhoneVerifySection from './PhoneVerifySection'
 import { cn } from '@/lib/utils'
 import { useUploadProfileImage } from '@/api/queries/useProfileImage'
+import NicknameFieldWithCheck from './NickNameFieldWithCheck'
 
 type MyInfoEditProps = {
   myInfo: MyInfoResponse
@@ -23,6 +24,8 @@ export default function MyInfoEdit({
   onSubmit,
 }: MyInfoEditProps) {
   const [nickname, setNickname] = useState('')
+  const [isNicknameVerified, setIsNicknameVerified] = useState(false)
+
   const [name, setName] = useState('')
   const [birthday, setBirthday] = useState('')
   const [gender, setGender] = useState<'M' | 'F'>('M')
@@ -36,6 +39,7 @@ export default function MyInfoEdit({
 
   useEffect(() => {
     setNickname(myInfo.nickname ?? '')
+    setIsNicknameVerified(true)
     setName(myInfo.name ?? '')
     setBirthday(myInfo.birthday ?? '')
     setGender(myInfo.gender ?? 'M')
@@ -45,6 +49,16 @@ export default function MyInfoEdit({
 
   const handleSubmit = async () => {
     try {
+      /**
+       * 닉네임이 변경된 경우 중복확인 완료 여부 체크
+       */
+      const isNicknameChanged =
+        nickname.trim() !== (myInfo.nickname ?? '').trim()
+
+      if (isNicknameChanged && !isNicknameVerified) {
+        toast.error('닉네임 중복확인을 완료해주세요.')
+        return
+      }
       /**
        * 휴대전화 번호를 변경한 경우에만 change-phone API 호출
        * 토큰이 없으면 기존 번호 유지로 간주
@@ -170,7 +184,22 @@ export default function MyInfoEdit({
             </div>
           </div>
           <div className="w-full space-y-10">
-            <div>
+            {/**
+             * 닉네임 인풋과 버튼 컴포넌트
+             * id - 인풋 id
+             * value - 인풋 value
+             * initialValue - 초기 value 값
+             * onChange - 인풋값이 변경 상태
+             * onVerifiedChange - 중복 확인 상태
+             */}
+            <NicknameFieldWithCheck
+              id="myInfo-nickname"
+              value={nickname}
+              initialValue={myInfo.nickname ?? ''}
+              onChange={setNickname}
+              onVerifiedChange={setIsNicknameVerified}
+            />
+            {/* <div>
               <div className="flex gap-3">
                 <InputField
                   id="nickname"
@@ -194,7 +223,7 @@ export default function MyInfoEdit({
                   </Button>
                 </div>
               </div>
-            </div>
+            </div> */}
 
             <div className="mb-25 flex flex-col gap-2">
               <InputField

--- a/src/features/mypage/NickNameFieldWithCheck.tsx
+++ b/src/features/mypage/NickNameFieldWithCheck.tsx
@@ -1,0 +1,147 @@
+import { useEffect, useState, type ChangeEvent } from 'react'
+
+import Button from '@/components/ui/button'
+import InputField from '@/components/common/InputField'
+import { cn } from '@/lib/utils'
+import { useCheckNickName } from '@/api/queries/useCheckNickName'
+import { NICKNAME_HELPTER_TEXT } from '@/constants/nickNameHelperText'
+import { AxiosError } from 'axios'
+
+type NicknameFieldWithCheckProps = {
+  id?: string
+  value: string
+  initialValue?: string
+  onChange: (value: string) => void
+  onVerifiedChange?: (isVerified: boolean) => void
+}
+
+type NicknameCheckStatus = 'default' | 'success' | 'danger'
+
+/**
+ * 닉네임 인풋과 버튼 - 중복 기능 구현
+ */
+export default function NicknameFieldWithCheck({
+  id,
+  value,
+  initialValue = '',
+  onChange,
+  onVerifiedChange,
+}: NicknameFieldWithCheckProps) {
+  const [status, setStatus] = useState<NicknameCheckStatus>('default')
+  const [helperText, setHelperText] = useState(NICKNAME_HELPTER_TEXT.default)
+  const [lastCheckedNickname, setLastCheckedNickname] = useState('')
+
+  const checkNicknameMutation = useCheckNickName()
+
+  const trimmedValue = value.trim()
+  const trimmedInitialValue = initialValue.trim()
+
+  const isInitialNickname = trimmedValue === trimmedInitialValue
+  const isVerified =
+    !!trimmedValue &&
+    (isInitialNickname ||
+      (status === 'success' && trimmedValue === lastCheckedNickname))
+
+  useEffect(() => {
+    onVerifiedChange?.(isVerified)
+  }, [isVerified, onVerifiedChange])
+
+  useEffect(() => {
+    setStatus('default')
+    setHelperText(NICKNAME_HELPTER_TEXT.default)
+    setLastCheckedNickname('')
+  }, [initialValue])
+
+  const handleChangeNickname = (e: ChangeEvent<HTMLInputElement>) => {
+    const nextValue = e.target.value
+    onChange(nextValue)
+
+    if (nextValue.trim() !== lastCheckedNickname) {
+      setStatus('default')
+      setHelperText(NICKNAME_HELPTER_TEXT.default)
+    }
+  }
+
+  const handleCheckNickname = async () => {
+    if (!trimmedValue) {
+      setStatus('danger')
+      setHelperText(NICKNAME_HELPTER_TEXT.empty)
+      return
+    }
+
+    try {
+      const result = await checkNicknameMutation.mutateAsync({
+        nickname: trimmedValue,
+      })
+
+      setStatus('success')
+      setHelperText(result.detail)
+      setLastCheckedNickname(trimmedValue)
+    } catch (error) {
+      let message = NICKNAME_HELPTER_TEXT.danger
+
+      if (error instanceof AxiosError) {
+        const errorDetail = error.response?.data?.error_detail
+
+        if (typeof errorDetail === 'string') {
+          message = errorDetail
+        }
+
+        if (
+          errorDetail &&
+          typeof errorDetail === 'object' &&
+          'nickname' in errorDetail &&
+          Array.isArray(errorDetail.nickname)
+        ) {
+          message = errorDetail.nickname[0]
+        }
+      }
+
+      setStatus('danger')
+      setHelperText(message)
+    }
+  }
+
+  const buttonDisabled =
+    checkNicknameMutation.isPending || !trimmedValue || isVerified
+
+  const inputStatus = isInitialNickname ? 'default' : status
+
+  const inputHelperText = isInitialNickname
+    ? NICKNAME_HELPTER_TEXT.default
+    : helperText
+
+  return (
+    <div>
+      <div className="flex gap-3">
+        <InputField
+          id={id}
+          value={value}
+          status={inputStatus}
+          helperText={inputHelperText}
+          onChange={handleChangeNickname}
+          placeholder="닉네임을 입력해주세요"
+          label="닉네임"
+          fieldLabelClassName="text-ui-gray-primary block text-base font-normal"
+          fieldHelperTextClassName="mt-1 text-xs font-medium"
+        />
+        <div className="flex items-center">
+          <Button
+            type="button"
+            variant={isVerified ? 'ghost' : 'outline'}
+            size="sm"
+            disabled={buttonDisabled}
+            onClick={handleCheckNickname}
+            className={cn(
+              'h-12 w-28 rounded-lg px-5 py-4 text-base',
+              isVerified &&
+                'border-grey-9 bg-grey-7 text-grey-9 hover:bg-grey-7'
+            )}
+          >
+            {checkNicknameMutation.isPending ? '확인중...' : '중복확인'}
+          </Button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -1,6 +1,7 @@
 import { availableCoursesHandlers } from './handlers/availableCoursesHandlers'
 import { changePasswordHandlers } from './handlers/changePasswordHandlers'
 import { changePhoneHandlers } from './handlers/changePhoneHandlers'
+import { checkNickNameHandlers } from './handlers/checkNickNameHandlers'
 import { examHandlers } from './handlers/examHandlers'
 import { mypageHandlers } from './handlers/myPageHandlers'
 import { profileImageHandlers } from './handlers/profileImageHandlers'
@@ -12,4 +13,5 @@ export const handlers = [
   ...changePasswordHandlers,
   ...changePhoneHandlers,
   ...profileImageHandlers,
+  ...checkNickNameHandlers,
 ]

--- a/src/mocks/handlers/checkNickNameHandlers.ts
+++ b/src/mocks/handlers/checkNickNameHandlers.ts
@@ -1,0 +1,41 @@
+import { http, HttpResponse } from 'msw'
+
+type CheckNicknameBody = {
+  nickname?: string
+}
+
+const duplicatedNicknames = ['관리자', 'admin', '오조오조']
+
+export const checkNickNameHandlers = [
+  http.post('/api/v1/accounts/check-nickname', async ({ request }) => {
+    const body = (await request.json()) as CheckNicknameBody
+    const nickname = body.nickname?.trim()
+
+    if (!nickname) {
+      return HttpResponse.json(
+        {
+          error_detail: {
+            nickname: ['이 필드는 필수 항목입니다.'],
+          },
+        },
+        { status: 400 }
+      )
+    }
+
+    if (duplicatedNicknames.includes(nickname)) {
+      return HttpResponse.json(
+        {
+          error_detail: '중복된 닉네임이 존재합니다.',
+        },
+        { status: 409 }
+      )
+    }
+
+    return HttpResponse.json(
+      {
+        detail: '사용가능한 닉네임 입니다.',
+      },
+      { status: 200 }
+    )
+  }),
+]

--- a/src/types/checkNickName.ts
+++ b/src/types/checkNickName.ts
@@ -1,0 +1,11 @@
+export type CheckNicknameRequest = {
+  nickname: string
+}
+
+export type CheckNicknameSuccessResponse = {
+  detail: string
+}
+
+export type CheckNicknameErrorResponse = {
+  error_detail: string | Record<string, string[]>
+}


### PR DESCRIPTION
## 📌 작업 내용

- 닉네임 중복 확인 API 함수와 Tanstack Query mutation 훅 추가
- 엔드포인트 상수 정의
- 성공/에러 응답 타입 추가
- MSW 핸들러 등록

- 닉네임 안내 및 에러 문구 상수 추가
- 닉네임 입력과 중복 확인 버튼을 묶은 전용 컴포넌트 구현
- 닉네임 변경 여부와 중복 확인 완료 상태 검증 로직 추가

## 🔗 관련 이슈

- closes #84 

## 📸 스크린샷 (선택)
<img width="736" height="260" alt="스크린샷 2026-03-19 오후 3 44 40" src="https://github.com/user-attachments/assets/ebb97721-6c5a-4a91-b08e-f42a5159f8cc" />
<img width="736" height="260" alt="스크린샷 2026-03-19 오후 3 44 53" src="https://github.com/user-attachments/assets/166f5001-8472-446a-9cc9-5851b2de31f0" />

## ✅ 체크리스트

- [ ] 코드 컨벤션 확인
- [ ] lint 에러 없음
- [ ] 빌드 정상 확인
