### PR TITLE
feat: 참가코드 입력기능 구현 

### DIFF
--- a/src/components/exam/CheatingModal.tsx
+++ b/src/components/exam/CheatingModal.tsx
@@ -37,7 +37,7 @@ function CheatingModal({
 
         <div>
           {message.map((line) => (
-            <p key={line} className="m-0">
+            <p key={line} className="m-0 text-[14px] text-gray-700">
               {line}
             </p>
           ))}

--- a/src/components/exam/ExamEntryCodeModal.tsx
+++ b/src/components/exam/ExamEntryCodeModal.tsx
@@ -1,0 +1,133 @@
+import { useEffect, useId, useState } from 'react'
+
+import Button from '@/components/ui/button'
+import Modal from '@/components/ui/modal/Modal'
+import Input from '../ui/input'
+
+type ExamEntryCodeModalProps = {
+  isOpen: boolean
+  examTitle: string
+  questionCount: number
+  timeLimit: number
+  imageSrc: string
+  imageAlt?: string
+  onClose: () => void
+  onConfirm: (code: string) => boolean | Promise<boolean>
+}
+
+export default function ExamEntryCodeModal({
+  isOpen,
+  examTitle,
+  questionCount,
+  timeLimit,
+  imageSrc,
+  imageAlt = '',
+  onClose,
+  onConfirm,
+}: ExamEntryCodeModalProps) {
+  const [entryCode, setEntryCode] = useState('')
+  const [errorMessage, setErrorMessage] = useState('')
+
+  const inputId = useId()
+  const descriptionId = useId()
+  const errorId = useId()
+
+  useEffect(() => {
+    if (!isOpen) {
+      setEntryCode('')
+      setErrorMessage('')
+    }
+  }, [isOpen])
+
+  const handleChangeEntryCode = (value: string) => {
+    setEntryCode(value)
+
+    if (errorMessage) {
+      setErrorMessage('')
+    }
+  }
+  const handleSubmit = async () => {
+    const trimmedCode = entryCode.trim()
+
+    if (!trimmedCode) {
+      setErrorMessage('참가코드를 입력해 주세요.')
+      return
+    }
+
+    const isValid = await onConfirm(trimmedCode)
+
+    if (!isValid) {
+      setErrorMessage('*코드번호가 일치하지 않습니다.')
+    }
+  }
+  const handleClose = () => {
+    setEntryCode('')
+    setErrorMessage('')
+    onClose()
+  }
+
+  return (
+    <Modal isOpen={isOpen} onClose={handleClose}>
+      <section className="mx-6 mt-2.5 mb-6">
+        <header className="flex flex-col items-center justify-center gap-2">
+          <img src={imageSrc} alt={imageAlt} />
+          <h2 className="text-ui-gray-primary text-[18px] font-semibold">
+            {examTitle}
+          </h2>
+          <p
+            id={descriptionId}
+            className="text-ui-gray-700 text-[14px] font-normal"
+          >
+            총 {questionCount}문항 ·{' '}
+            <span className="text-primary-default">
+              {' '}
+              제한시간 {timeLimit}분
+            </span>
+          </p>
+        </header>
+
+        <form
+          onSubmit={async (event) => {
+            event.preventDefault()
+            await handleSubmit()
+          }}
+        >
+          <div className="flex flex-col">
+            <label
+              className="text-ui-gray-primary mt-8 mb-2 text-[16px] font-normal"
+              htmlFor={inputId}
+            >
+              참가코드 입력
+            </label>
+            <Input
+              id={inputId}
+              type="text"
+              value={entryCode}
+              onChange={(event) => {
+                handleChangeEntryCode(event.target.value)
+              }}
+              placeholder="6자리를 입력해주세요."
+              aria-invalid={Boolean(errorMessage)}
+              aria-describedby={errorMessage ? errorId : descriptionId}
+              className={
+                errorMessage ? 'border-other-red focus:border-other-red' : ''
+              }
+            />
+            {errorMessage ? (
+              <p
+                className="text-other-red mt-[5px] text-[12px] font-normal"
+                id={errorId}
+              >
+                {errorMessage}
+              </p>
+            ) : null}
+          </div>
+
+          <Button type="submit" className="mt-6 w-full rounded-[4px]">
+            시험시작
+          </Button>
+        </form>
+      </section>
+    </Modal>
+  )
+}

--- a/src/features/mypage/MyExamTab.tsx
+++ b/src/features/mypage/MyExamTab.tsx
@@ -89,11 +89,12 @@ export default function MyExamTab() {
                         setActiveTab(tab)
                       }}
                       aria-pressed={isActive}
-                      className={`cursor-pointer border-b-2 p-4 ${
+                      className={cn(
+                        'cursor-pointer border-b-2 p-4',
                         isActive
                           ? 'border-[#721AE3] text-[#721AE3]'
                           : 'border-transparent text-gray-400 hover:text-[#721AE3]'
-                      }`}
+                      )}
                     >
                       {EXAM_TAB_LABEL[tab]}
                     </button>
@@ -121,7 +122,11 @@ export default function MyExamTab() {
                     key={item.id}
                     className="flex items-center gap-4 rounded-lg border px-8 py-7"
                   >
-                    <img src={subjectIcon} alt="" className="h-12 w-12" />
+                    <img
+                      src={subjectIcon}
+                      alt={`${item.exam.subject.title} 과목 아이콘`}
+                      className="h-12 w-12"
+                    />
 
                     <div className="flex-1 flex-col">
                       <div className="mb-2 flex items-center gap-3">
@@ -180,7 +185,9 @@ export default function MyExamTab() {
         questionCount={selectedExam?.question_count ?? 0}
         timeLimit={selectedExam?.duration_time ?? 20}
         imageSrc={modalImageSrc}
-        imageAlt={selectedExam?.exam.subject.title ?? ''}
+        imageAlt={
+          selectedExam ? `${selectedExam.exam.subject.title} 과목 아이콘` : ''
+        }
         onClose={handleCloseEntryCodeModal}
         onConfirm={handleConfirmEntryCode}
       />

--- a/src/features/mypage/MyExamTab.tsx
+++ b/src/features/mypage/MyExamTab.tsx
@@ -1,4 +1,5 @@
 import ExamEmptyState from '@/components/exam/ExamEmptyState'
+import ExamEntryCodeModal from '@/components/exam/ExamEntryCodeModal'
 import { EXAM_SUBJECT_ICON_MAP } from '@/constants/exam/examSubjectIconMap'
 import {
   EMPTY_TITLE_MAP,
@@ -11,120 +12,178 @@ import { cn } from '@/lib/utils'
 import { mockExamDeploymentList } from '@/mocks/data/mockExamDeploymentList'
 import type { ExamTabType } from '@/types/mypage-type/examDeployment'
 import { useState } from 'react'
-import { Link } from 'react-router-dom'
+import { useNavigate } from 'react-router-dom'
+
+type ExamItem = (typeof mockExamDeploymentList.results)[number]
 
 export default function MyExamTab() {
   const [activeTab, setActiveTab] = useState<ExamTabType>('all')
+  const [selectedExam, setSelectedExam] = useState<ExamItem | null>(null)
+  const [isEntryCodeModalOpen, setIsEntryCodeModalOpen] = useState(false)
+
+  const navigate = useNavigate()
+
   const filteredExamList = mockExamDeploymentList.results.filter((item) => {
     if (activeTab === 'all') {
       return true
     }
     return item.exam_info.status === activeTab
   })
-  return (
-    <section className="w-186">
-      {/* 제목 */}
-      <h1 className="text-primary mb-15 text-[32px] leading-[140%] font-bold tracking-[-0.03em]">
-        쪽지시험
-      </h1>
-      {/* 상단 탭 */}
-      <div className="border-grey-9 border-b">
-        <nav aria-label="쪽지시험 상태 탭">
-          <ul className="flex gap-[30px]">
-            {EXAM_TABS.map((tab) => {
-              const isActive = activeTab === tab
-              return (
-                <li
-                  key={tab}
-                  className="text-[20px] leading-[140%] font-bold tracking-[-0.03em]"
-                >
-                  <button
-                    type="button"
-                    onClick={() => {
-                      setActiveTab(tab)
-                    }}
-                    aria-pressed={isActive}
-                    className={`cursor-pointer border-b-2 p-4 ${
-                      isActive
-                        ? 'border-[#721AE3] text-[#721AE3]'
-                        : 'border-transparent text-gray-400 hover:text-[#721AE3]'
-                    }`}
-                  >
-                    {EXAM_TAB_LABEL[tab]}
-                  </button>
-                </li>
-              )
-            })}
-          </ul>
-        </nav>
-      </div>
-      {/* 콘텐츠(시험과목) 영역 */}
-      <div className="mt-6">
-        {filteredExamList.length === 0 ? (
-          <ExamEmptyState title={EMPTY_TITLE_MAP[activeTab]} />
-        ) : (
-          <ul className="flex flex-col gap-4">
-            {filteredExamList.map((item) => {
-              // 과목명에 맞는 아이콘과 시험 상태별 UI 메타 정보를 가져옴, ts검증
-              const subjectTitle = item.exam.subject
-                .title as keyof typeof EXAM_SUBJECT_ICON_MAP
-              const subjectIcon = EXAM_SUBJECT_ICON_MAP[subjectTitle]
-              const statusMeta = EXAM_STATUS_META[item.exam_info.status]
-              const isDone = item.exam_info.status === 'done'
-              // 아직 api data로 이동 X
-              const buttonPath = isDone
-                ? getQuizResultPage(item.id)
-                : getQuizPage(item.id)
 
-              return (
-                <li
-                  key={item.id}
-                  className="flex items-center gap-4 rounded-lg border px-8 py-7"
-                >
-                  <img src={subjectIcon} alt="" className="h-12 w-12" />
-                  <div className="flex-1 flex-col">
-                    <div className="mb-2 flex items-center gap-3">
-                      <h3 className="text-[18px] leading-[140%] font-semibold tracking-[-0.03em]">
-                        {item.exam.title}
-                      </h3>
-                      <p
-                        className={cn(
-                          'flex items-center justify-center rounded-[2px] px-2 py-1 text-[12px]',
-                          statusMeta.badgeClassName
-                        )}
-                      >
-                        {statusMeta.label}
-                      </p>
-                    </div>
-                    <div className="text-[14px] leading-[140%] font-normal tracking-[-0.03em] text-gray-700">
-                      {isDone ? (
-                        <p>
-                          {item.exam.subject.title} ㆍ {item.exam_info.score}점/
-                          {item.total_score}점 ㆍ{' '}
-                          {item.exam_info.correct_answer_count}/
-                          {item.question_count}개 정답
-                        </p>
-                      ) : (
-                        <p>
-                          {item.exam.subject.title} ㆍ 응시하고 점수를
-                          확인해보세요!
-                        </p>
-                      )}
-                    </div>
-                  </div>
-                  {/* 버튼영역 */}
-                  <Link
-                    to={buttonPath}
-                    className={`${statusMeta.buttonClassName} shrink-0`}
+  const handleExamActionClick = (item: ExamItem) => {
+    const isDone = item.exam_info.status === 'done'
+    if (isDone) {
+      navigate(getQuizResultPage(item.id))
+      return
+    }
+    setSelectedExam(item)
+    setIsEntryCodeModalOpen(true)
+  }
+
+  const handleCloseEntryCodeModal = () => {
+    setIsEntryCodeModalOpen(false)
+    setSelectedExam(null)
+  }
+
+  const handleConfirmEntryCode = async (code: string) => {
+    if (!selectedExam) {
+      return false
+    }
+    const isValidCode = code === '777777'
+    if (!isValidCode) {
+      return false
+    }
+    setIsEntryCodeModalOpen(false)
+    navigate(getQuizPage(selectedExam.id))
+    return true
+  }
+
+  const selectedSubjectTitle = selectedExam?.exam.subject.title as
+    | keyof typeof EXAM_SUBJECT_ICON_MAP
+    | undefined
+
+  const modalImageSrc = selectedSubjectTitle
+    ? EXAM_SUBJECT_ICON_MAP[selectedSubjectTitle]
+    : ''
+  return (
+    <>
+      <section className="w-186">
+        <h1 className="text-primary mb-15 text-[32px] leading-[140%] font-bold tracking-[-0.03em]">
+          쪽지시험
+        </h1>
+
+        <div className="border-grey-9 border-b">
+          <nav aria-label="쪽지시험 상태 탭">
+            <ul className="flex gap-[30px]">
+              {EXAM_TABS.map((tab) => {
+                const isActive = activeTab === tab
+
+                return (
+                  <li
+                    key={tab}
+                    className="text-[20px] leading-[140%] font-bold tracking-[-0.03em]"
                   >
-                    {statusMeta.buttonText}
-                  </Link>
-                </li>
-              )
-            })}
-          </ul>
-        )}
-      </div>
-    </section>
+                    <button
+                      type="button"
+                      onClick={() => {
+                        setActiveTab(tab)
+                      }}
+                      aria-pressed={isActive}
+                      className={`cursor-pointer border-b-2 p-4 ${
+                        isActive
+                          ? 'border-[#721AE3] text-[#721AE3]'
+                          : 'border-transparent text-gray-400 hover:text-[#721AE3]'
+                      }`}
+                    >
+                      {EXAM_TAB_LABEL[tab]}
+                    </button>
+                  </li>
+                )
+              })}
+            </ul>
+          </nav>
+        </div>
+
+        <div className="mt-6">
+          {filteredExamList.length === 0 ? (
+            <ExamEmptyState title={EMPTY_TITLE_MAP[activeTab]} />
+          ) : (
+            <ul className="flex flex-col gap-4">
+              {filteredExamList.map((item) => {
+                const subjectTitle = item.exam.subject
+                  .title as keyof typeof EXAM_SUBJECT_ICON_MAP
+                const subjectIcon = EXAM_SUBJECT_ICON_MAP[subjectTitle]
+                const statusMeta = EXAM_STATUS_META[item.exam_info.status]
+                const isDone = item.exam_info.status === 'done'
+
+                return (
+                  <li
+                    key={item.id}
+                    className="flex items-center gap-4 rounded-lg border px-8 py-7"
+                  >
+                    <img src={subjectIcon} alt="" className="h-12 w-12" />
+
+                    <div className="flex-1 flex-col">
+                      <div className="mb-2 flex items-center gap-3">
+                        <h3 className="text-[18px] leading-[140%] font-semibold tracking-[-0.03em]">
+                          {item.exam.title}
+                        </h3>
+
+                        <p
+                          className={cn(
+                            'flex items-center justify-center rounded-[2px] px-2 py-1 text-[12px]',
+                            statusMeta.badgeClassName
+                          )}
+                        >
+                          {statusMeta.label}
+                        </p>
+                      </div>
+
+                      <div className="text-[14px] leading-[140%] font-normal tracking-[-0.03em] text-gray-700">
+                        {isDone ? (
+                          <p>
+                            {item.exam.subject.title} ㆍ {item.exam_info.score}
+                            점/
+                            {item.total_score}점 ㆍ{' '}
+                            {item.exam_info.correct_answer_count}/
+                            {item.question_count}개 정답
+                          </p>
+                        ) : (
+                          <p>
+                            {item.exam.subject.title} ㆍ 응시하고 점수를
+                            확인해보세요!
+                          </p>
+                        )}
+                      </div>
+                    </div>
+
+                    <button
+                      type="button"
+                      onClick={() => {
+                        handleExamActionClick(item)
+                      }}
+                      className={`${statusMeta.buttonClassName} shrink-0`}
+                    >
+                      {statusMeta.buttonText}
+                    </button>
+                  </li>
+                )
+              })}
+            </ul>
+          )}
+        </div>
+      </section>
+
+      <ExamEntryCodeModal
+        isOpen={isEntryCodeModalOpen}
+        examTitle={selectedExam?.exam.title ?? ''}
+        questionCount={selectedExam?.question_count ?? 0}
+        timeLimit={selectedExam?.duration_time ?? 20}
+        imageSrc={modalImageSrc}
+        imageAlt={selectedExam?.exam.subject.title ?? ''}
+        onClose={handleCloseEntryCodeModal}
+        onConfirm={handleConfirmEntryCode}
+      />
+    </>
   )
 }

--- a/src/mocks/data/mockExamDeploymentList.ts
+++ b/src/mocks/data/mockExamDeploymentList.ts
@@ -25,7 +25,7 @@ export const mockExamDeploymentList: ExamDeploymentListResponse = {
         correct_answer_count: 8,
       },
       is_done: true,
-      duration_time: 20,
+      duration_time: 25,
     },
     {
       id: 102,
@@ -40,7 +40,7 @@ export const mockExamDeploymentList: ExamDeploymentListResponse = {
           thumbnail_img_url: 'https://cdn.ozcoding/aws.png',
         },
       },
-      question_count: 10,
+      question_count: 12,
       total_score: 100,
       exam_info: {
         status: 'pending',


### PR DESCRIPTION
## 📌 작업 내용

- 쪽지시험 입장 코드 입력 모달 컴포넌트 구현
- 시험 정보(제목, 문항 수, 제한 시간, 이미지) 표시 UI 추가
- 입장 코드 입력값 state 및 에러 메시지 state 처리

## 🔗 관련 이슈

- closes #88 

## 📸 스크린샷 (선택)
<img width="672" height="611" alt="스크린샷 2026-03-20 144302" src="https://github.com/user-attachments/assets/ed3157b9-68ff-4879-aa08-6ae2765b668a" />

## ✅ 체크리스트

- [ ] 코드 컨벤션 확인
- [ ] lint 에러 없음
- [ ] 빌드 정상 확인
