### PR TITLE
feat: 내 정보 수정 폼 스키마 검증 및 에러 처리 추가

### DIFF
--- a/src/features/mypage/MyInfoEdit.tsx
+++ b/src/features/mypage/MyInfoEdit.tsx
@@ -11,11 +11,19 @@ import PhoneVerifySection from './PhoneVerifySection'
 import { cn } from '@/lib/utils'
 import { useUploadProfileImage } from '@/api/queries/useProfileImage'
 import NicknameFieldWithCheck from './NickNameFieldWithCheck'
+import {
+  formatBirthdayInput,
+  updateMyInfoFormSchema,
+} from '@/schemas/updateMyInfoSchema'
+import {
+  parseUpdateMyInfoError,
+  type MyInfoFieldErrors,
+} from '@/utils/parseUpdateMyInfoError'
 
 type MyInfoEditProps = {
   myInfo: MyInfoResponse
   isPending: boolean
-  onSubmit: (payload: UpdateMyInfoRequest) => Promise<void> | void
+  onSubmit: (payload: UpdateMyInfoRequest) => Promise<void>
 }
 
 export default function MyInfoEdit({
@@ -23,16 +31,17 @@ export default function MyInfoEdit({
   isPending,
   onSubmit,
 }: MyInfoEditProps) {
-  const [nickname, setNickname] = useState('')
+  const [nickname, setNickname] = useState(myInfo.nickname ?? '')
   const [isNicknameVerified, setIsNicknameVerified] = useState(false)
 
-  const [name, setName] = useState('')
-  const [birthday, setBirthday] = useState('')
-  const [gender, setGender] = useState<'M' | 'F'>('M')
+  const [name, setName] = useState(myInfo.name ?? '')
+  const [birthday, setBirthday] = useState(myInfo.birthday ?? '')
+  const [gender, setGender] = useState<'M' | 'F'>(myInfo.gender ?? 'M')
   const [phoneNumber, setPhoneNumber] = useState(myInfo.phone_number ?? '')
   const [verifiedPhoneToken, setVerifiedPhoneToken] = useState<string | null>(
     null
   )
+  const [errors, setErrors] = useState<MyInfoFieldErrors>({})
 
   const changePhoneMutation = useChangePhone()
   const uploadProfileImageMutation = useUploadProfileImage()
@@ -45,10 +54,31 @@ export default function MyInfoEdit({
     setGender(myInfo.gender ?? 'M')
     setPhoneNumber(myInfo.phone_number ?? '')
     setVerifiedPhoneToken(null)
+    setErrors({})
   }, [myInfo])
 
   const handleSubmit = async () => {
     try {
+      const parsed = updateMyInfoFormSchema.safeParse({
+        nickname,
+        name,
+        birthday,
+        gender,
+      })
+
+      if (!parsed.success) {
+        const fieldErrors = parsed.error.flatten().fieldErrors
+
+        setErrors({
+          nickname: fieldErrors.nickname?.[0],
+          name: fieldErrors.name?.[0],
+          birthday: fieldErrors.birthday?.[0],
+          gender: fieldErrors.gender?.[0],
+        })
+
+        toast.error('입력값을 다시 확인해주세요.')
+        return
+      }
       /**
        * 닉네임이 변경된 경우 중복확인 완료 여부 체크
        */
@@ -56,6 +86,10 @@ export default function MyInfoEdit({
         nickname.trim() !== (myInfo.nickname ?? '').trim()
 
       if (isNicknameChanged && !isNicknameVerified) {
+        setErrors((prev) => ({
+          ...prev,
+          nickname: '닉네임 중복확인을 완료해주세요.',
+        }))
         toast.error('닉네임 중복확인을 완료해주세요.')
         return
       }
@@ -73,17 +107,29 @@ export default function MyInfoEdit({
         setPhoneNumber(result.phone_number)
         setVerifiedPhoneToken(null)
       }
+      setErrors({})
 
       await onSubmit({
-        nickname,
-        name,
-        birthday,
-        gender,
+        nickname: parsed.data.nickname.trim(),
+        name: parsed.data.name.trim(),
+        birthday: parsed.data.birthday,
+        gender: parsed.data.gender,
       })
 
       toast.success('내 정보가 저장되었습니다.')
-    } catch {
-      toast.error('저장에 실패했습니다.')
+    } catch (error) {
+      const parsedError = parseUpdateMyInfoError(error)
+
+      if (
+        parsedError.nickname ||
+        parsedError.name ||
+        parsedError.birthday ||
+        parsedError.gender
+      ) {
+        setErrors(parsedError)
+      }
+
+      toast.error(parsedError.common ?? '저장에 실패했습니다.')
     }
   }
 
@@ -196,34 +242,13 @@ export default function MyInfoEdit({
               id="myInfo-nickname"
               value={nickname}
               initialValue={myInfo.nickname ?? ''}
-              onChange={setNickname}
+              onChange={(value) => {
+                setNickname(value)
+                setErrors((prev) => ({ ...prev, nickname: undefined }))
+              }}
               onVerifiedChange={setIsNicknameVerified}
+              externalError={errors.nickname}
             />
-            {/* <div>
-              <div className="flex gap-3">
-                <InputField
-                  id="nickname"
-                  value={nickname}
-                  status="default"
-                  helperText="*한글 2자, 영문 및 숫자 10자까지 혼용할 수 있어요"
-                  onChange={(e) => setNickname(e.target.value)}
-                  placeholder={nickname}
-                  label="닉네임"
-                  fieldLabelClassName="text-ui-gray-primary block text-base font-normal"
-                  fieldHelperTextClassName="text-ui-gray-400 mt-2 text-xs font-medium"
-                />
-                <div className="flex items-center">
-                  <Button
-                    type="button"
-                    variant="ghost"
-                    size="sm"
-                    className="bg-ui-gray-200 border-ui-gray-250 border px-5 py-4 text-base"
-                  >
-                    중복확인
-                  </Button>
-                </div>
-              </div>
-            </div> */}
 
             <div className="mb-25 flex flex-col gap-2">
               <InputField
@@ -248,9 +273,14 @@ export default function MyInfoEdit({
               <InputField
                 id="name"
                 value={name}
-                onChange={(e) => setName(e.target.value)}
-                placeholder={name}
+                onChange={(e) => {
+                  setName(e.target.value)
+                  setErrors((prev) => ({ ...prev, name: undefined }))
+                }}
+                status={errors.name ? 'danger' : 'default'}
+                placeholder="이름을 입력해주세요"
                 label="이름"
+                helperText={errors.name}
                 fieldLabelClassName="text-ui-gray-primary block text-base font-normal"
               />
             </div>
@@ -269,7 +299,10 @@ export default function MyInfoEdit({
               <div className="flex gap-3">
                 <button
                   type="button"
-                  onClick={() => setGender('M')}
+                  onClick={() => {
+                    setGender('M')
+                    setErrors((prev) => ({ ...prev, gender: undefined }))
+                  }}
                   className={cn(
                     `flex h-10.5 min-w-20 cursor-pointer items-center justify-center rounded-full border px-7 py-4 text-base font-semibold`,
                     gender === 'M'
@@ -282,7 +315,10 @@ export default function MyInfoEdit({
 
                 <button
                   type="button"
-                  onClick={() => setGender('F')}
+                  onClick={() => {
+                    setGender('M')
+                    setErrors((prev) => ({ ...prev, gender: undefined }))
+                  }}
                   className={cn(
                     'flex h-10.5 min-w-20 cursor-pointer items-center justify-center rounded-full border px-7 py-4 text-base font-semibold',
                     gender === 'F'
@@ -298,9 +334,16 @@ export default function MyInfoEdit({
             <InputField
               id="birthday"
               value={birthday}
-              onChange={(e) => setBirthday(e.target.value)}
-              placeholder={birthday}
+              onChange={(e) => {
+                setBirthday(formatBirthdayInput(e.target.value))
+                setErrors((prev) => ({ ...prev, birthday: undefined }))
+              }}
+              placeholder="숫자 8자리를 입력해주세요."
               label="생년월일"
+              status={errors.birthday ? 'danger' : 'default'}
+              helperText={
+                errors.birthday ?? '생년월일 8자리를 숫자로 입력해주세요.'
+              }
               fieldLabelClassName="text-ui-gray-primary block text-base font-normal"
             />
           </div>

--- a/src/features/mypage/MyInfoTab.tsx
+++ b/src/features/mypage/MyInfoTab.tsx
@@ -12,7 +12,7 @@ export default function MyInfoTab() {
   const { data: myInfo, isLoading: isMyInfoLoading } = useGetMyInfo()
   const { data: enrolledCourses = [], isLoading: isCoursesLoading } =
     useGetMyEnrolledCourses()
-  const { mutate: patchMyInfo, isPending } = usePatchMyInfo()
+  const { mutateAsync: patchMyInfo, isPending } = usePatchMyInfo()
 
   if (isMyInfoLoading || isCoursesLoading) {
     return <Loading />
@@ -33,12 +33,9 @@ export default function MyInfoTab() {
       <MyInfoEdit
         myInfo={myInfo}
         isPending={isPending}
-        onSubmit={(payload) => {
-          patchMyInfo(payload, {
-            onSuccess: () => {
-              setIsEditMode(false)
-            },
-          })
+        onSubmit={async (payload) => {
+          await patchMyInfo(payload)
+          setIsEditMode(false)
         }}
       />
     )

--- a/src/features/mypage/NickNameFieldWithCheck.tsx
+++ b/src/features/mypage/NickNameFieldWithCheck.tsx
@@ -6,6 +6,7 @@ import { cn } from '@/lib/utils'
 import { useCheckNickName } from '@/api/queries/useCheckNickName'
 import { NICKNAME_HELPTER_TEXT } from '@/constants/nickNameHelperText'
 import { AxiosError } from 'axios'
+import { nicknameSchema } from '@/schemas/updateMyInfoSchema'
 
 type NicknameFieldWithCheckProps = {
   id?: string
@@ -13,6 +14,7 @@ type NicknameFieldWithCheckProps = {
   initialValue?: string
   onChange: (value: string) => void
   onVerifiedChange?: (isVerified: boolean) => void
+  externalError?: string
 }
 
 type NicknameCheckStatus = 'default' | 'success' | 'danger'
@@ -26,6 +28,7 @@ export default function NicknameFieldWithCheck({
   initialValue = '',
   onChange,
   onVerifiedChange,
+  externalError,
 }: NicknameFieldWithCheckProps) {
   const [status, setStatus] = useState<NicknameCheckStatus>('default')
   const [helperText, setHelperText] = useState(NICKNAME_HELPTER_TEXT.default)
@@ -35,6 +38,8 @@ export default function NicknameFieldWithCheck({
 
   const trimmedValue = value.trim()
   const trimmedInitialValue = initialValue.trim()
+
+  const nicknameValidation = nicknameSchema.safeParse(value)
 
   const isInitialNickname = trimmedValue === trimmedInitialValue
   const isVerified =
@@ -52,20 +57,66 @@ export default function NicknameFieldWithCheck({
     setLastCheckedNickname('')
   }, [initialValue])
 
+  useEffect(() => {
+    if (!externalError) {
+      return
+    }
+
+    setStatus('danger')
+    setHelperText(externalError)
+  }, [externalError])
+
   const handleChangeNickname = (e: ChangeEvent<HTMLInputElement>) => {
     const nextValue = e.target.value
+    const nextTrimmedValue = nextValue.trim()
+
     onChange(nextValue)
 
-    if (nextValue.trim() !== lastCheckedNickname) {
-      setStatus('default')
-      setHelperText(NICKNAME_HELPTER_TEXT.default)
+    if (nextTrimmedValue === lastCheckedNickname) {
+      return
     }
+
+    setStatus('default')
+
+    if (!nextTrimmedValue) {
+      setHelperText(NICKNAME_HELPTER_TEXT.default)
+      return
+    }
+
+    const result = nicknameSchema.safeParse(nextValue)
+
+    if (!result.success) {
+      setHelperText(
+        result.error.issues[0]?.message ?? NICKNAME_HELPTER_TEXT.default
+      )
+      return
+    }
+
+    setHelperText(NICKNAME_HELPTER_TEXT.default)
   }
 
   const handleCheckNickname = async () => {
     if (!trimmedValue) {
       setStatus('danger')
       setHelperText(NICKNAME_HELPTER_TEXT.empty)
+      return
+    }
+
+    const validationResult = nicknameSchema.safeParse(value)
+
+    if (!validationResult.success) {
+      setStatus('danger')
+      setHelperText(
+        validationResult.error.issues[0]?.message ??
+          NICKNAME_HELPTER_TEXT.danger
+      )
+      return
+    }
+
+    if (isInitialNickname) {
+      setStatus('success')
+      setHelperText('현재 사용 중인 닉네임입니다.')
+      setLastCheckedNickname(trimmedValue)
       return
     }
 
@@ -103,44 +154,49 @@ export default function NicknameFieldWithCheck({
   }
 
   const buttonDisabled =
-    checkNicknameMutation.isPending || !trimmedValue || isVerified
+    checkNicknameMutation.isPending ||
+    !trimmedValue ||
+    !nicknameValidation.success ||
+    isVerified
 
-  const inputStatus = isInitialNickname ? 'default' : status
+  let inputStatus: NicknameCheckStatus = status
+  let inputHelperText = helperText
 
-  const inputHelperText = isInitialNickname
-    ? NICKNAME_HELPTER_TEXT.default
-    : helperText
+  if (externalError && !isVerified) {
+    inputStatus = 'danger'
+    inputHelperText = externalError
+  } else if (isInitialNickname) {
+    inputStatus = 'default'
+    inputHelperText = NICKNAME_HELPTER_TEXT.default
+  }
 
   return (
-    <div>
-      <div className="flex gap-3">
-        <InputField
-          id={id}
-          value={value}
-          status={inputStatus}
-          helperText={inputHelperText}
-          onChange={handleChangeNickname}
-          placeholder="닉네임을 입력해주세요"
-          label="닉네임"
-          fieldLabelClassName="text-ui-gray-primary block text-base font-normal"
-          fieldHelperTextClassName="mt-1 text-xs font-medium"
-        />
-        <div className="flex items-center">
-          <Button
-            type="button"
-            variant={isVerified ? 'ghost' : 'outline'}
-            size="sm"
-            disabled={buttonDisabled}
-            onClick={handleCheckNickname}
-            className={cn(
-              'h-12 w-28 rounded-lg px-5 py-4 text-base',
-              isVerified &&
-                'border-grey-9 bg-grey-7 text-grey-9 hover:bg-grey-7'
-            )}
-          >
-            {checkNicknameMutation.isPending ? '확인중...' : '중복확인'}
-          </Button>
-        </div>
+    <div className="flex gap-3">
+      <InputField
+        id={id}
+        value={value}
+        status={inputStatus}
+        helperText={inputHelperText}
+        onChange={handleChangeNickname}
+        placeholder="닉네임을 입력해주세요"
+        label="닉네임"
+        fieldLabelClassName="text-ui-gray-primary block text-base font-normal"
+        fieldHelperTextClassName="mt-1 text-xs font-medium"
+      />
+      <div className="flex items-center">
+        <Button
+          type="button"
+          variant={isVerified ? 'ghost' : 'outline'}
+          size="sm"
+          disabled={buttonDisabled}
+          onClick={handleCheckNickname}
+          className={cn(
+            'h-12 w-28 rounded-lg px-5 py-4 text-base',
+            isVerified && 'border-grey-9 bg-grey-7 text-grey-9 hover:bg-grey-7'
+          )}
+        >
+          {checkNicknameMutation.isPending ? '확인중...' : '중복확인'}
+        </Button>
       </div>
     </div>
   )

--- a/src/mocks/handlers/myPageHandlers.ts
+++ b/src/mocks/handlers/myPageHandlers.ts
@@ -7,7 +7,7 @@ let myInfoMock: MyInfoResponse = {
   nickname: '오조오조',
   name: '김오조',
   phone_number: '010-1234-1234',
-  birthday: '2000.12.25',
+  birthday: '2000-12-25',
   gender: 'M',
   profile_img_url: null,
   created_at: '2025-10-30T14:01:57.505250+09:00',
@@ -57,9 +57,9 @@ export const mypageHandlers = [
   http.delete('/api/v1/accounts/me', async ({ request }) => {
     /**
      * TODO: authHeader 수정 예정
-     */
-    // const authHeader = request.headers.get('Authorization')
-
+     * // const authHeader = request.headers.get('Authorization')
+     * 
+     * 
     // if (!authHeader) {
     //   return HttpResponse.json(
     //     {
@@ -68,6 +68,7 @@ export const mypageHandlers = [
     //     { status: 401 }
     //   )
     // }
+     */
 
     const body = (await request.json()) as {
       reason?: string

--- a/src/schemas/updateMyInfoSchema.ts
+++ b/src/schemas/updateMyInfoSchema.ts
@@ -1,0 +1,60 @@
+import { z } from 'zod'
+
+const NICKNAME_REGEX = /^[가-힣a-zA-Z0-9]+$/
+const BIRTHDAY_REGEX = /^\d{4}-\d{2}-\d{2}$/
+
+export const genderSchema = z.enum(['M', 'F'])
+
+const isValidBirthday = (value: string) => {
+  if (!BIRTHDAY_REGEX.test(value)) {
+    return false
+  }
+
+  const [year, month, day] = value.split('-').map(Number)
+
+  const date = new Date(year, month - 1, day)
+
+  return (
+    date.getFullYear() === year &&
+    date.getMonth() === month - 1 &&
+    date.getDate() === day
+  )
+}
+
+export const nicknameSchema = z
+  .string()
+  .trim()
+  .min(2, '닉네임은 2자 이상 입력해주세요.')
+  .max(10, '닉네임은 10자 이하로 입력해주세요.')
+  .regex(NICKNAME_REGEX, '닉네임은 한글, 영문, 숫자만 사용할 수 있어요.')
+
+export const updateMyInfoFormSchema = z.object({
+  nickname: nicknameSchema,
+  name: z.string().trim().min(1, '이름을 입력해주세요.'),
+  birthday: z
+    .string()
+    .trim()
+    .regex(BIRTHDAY_REGEX, '생년월일은 YYYYMMDD 형식으로 입력해주세요.')
+    .refine(isValidBirthday, '올바른 생년월일을 입력해주세요.'),
+  gender: genderSchema,
+})
+
+export type UpdateMyInfoFormValues = z.infer<typeof updateMyInfoFormSchema>
+
+/**
+ * 숫자만 입력받아 YYYY-MM-DD 형태로 자동 포맷
+ * 예: 20260101 -> 2026-01-01
+ */
+export const formatBirthdayInput = (value: string) => {
+  const numbers = value.replace(/\D/g, '').slice(0, 8)
+
+  if (numbers.length <= 4) {
+    return numbers
+  }
+
+  if (numbers.length <= 6) {
+    return `${numbers.slice(0, 4)}-${numbers.slice(4)}`
+  }
+
+  return `${numbers.slice(0, 4)}-${numbers.slice(4, 6)}-${numbers.slice(6, 8)}`
+}

--- a/src/utils/parseUpdateMyInfoError.ts
+++ b/src/utils/parseUpdateMyInfoError.ts
@@ -1,0 +1,53 @@
+import type { ErrorDetailResponse } from '@/types/api-response/myPageResponse'
+import { AxiosError } from 'axios'
+
+export type MyInfoFieldErrors = {
+  nickname?: string
+  name?: string
+  birthday?: string
+  gender?: string
+  phone_number?: string
+  common?: string
+}
+
+const getFirstErrorMessage = (value: unknown) => {
+  if (Array.isArray(value) && typeof value[0] === 'string') {
+    return value[0]
+  }
+
+  return undefined
+}
+
+/**
+ * 마이페이지 - 내 정보 수정 에러 처리 함수
+ */
+export const parseUpdateMyInfoError = (error: unknown): MyInfoFieldErrors => {
+  const fallbackMessage = '요청 처리 중 오류가 발생했습니다.'
+
+  if (!(error instanceof AxiosError)) {
+    return { common: fallbackMessage }
+  }
+
+  const responseData = error.response?.data as ErrorDetailResponse | undefined
+  const errorDetail = responseData?.error_detail
+
+  if (!errorDetail) {
+    return { common: fallbackMessage }
+  }
+
+  if (typeof errorDetail === 'string') {
+    return { common: errorDetail }
+  }
+
+  if (typeof errorDetail === 'object') {
+    return {
+      nickname: getFirstErrorMessage(errorDetail.nickname),
+      name: getFirstErrorMessage(errorDetail.name),
+      birthday: getFirstErrorMessage(errorDetail.birthday),
+      gender: getFirstErrorMessage(errorDetail.gender),
+      common: undefined,
+    }
+  }
+
+  return { common: fallbackMessage }
+}


### PR DESCRIPTION
## 📌 작업 내용

- 내 정보 수정 관련 zod 스키마 추가
- 서버 응답을 필드 에러로 변환하는 Parse 유틸 구현
- 내 정보 수정 화면에 클라이언트 검증 및 서버 에러 표시 연동
- 닉네임 중복 확인 컴포넌트에 스키마 검증과 외부 에러 처리 추가
- 내 정보 수정 mutation을 async 흐름으로 정리

## 🔗 관련 이슈

- closes #86 

## 📸 스크린샷 (선택)

## ✅ 체크리스트

- [ ] 코드 컨벤션 확인
- [ ] lint 에러 없음
- [ ] 빌드 정상 확인
