### PR TITLE
feat: 로그아웃 API 및 유저 메뉴 연동 추가

### DIFF
--- a/src/api/mypage.ts
+++ b/src/api/mypage.ts
@@ -86,3 +86,12 @@ export const changePhone = async (payload: ChangePhoneRequest) => {
 
   return data
 }
+
+export type LogoutResponse = {
+  detail: string
+}
+
+export const logout = async (): Promise<LogoutResponse> => {
+  const { data } = await api.post<LogoutResponse>(APIS_PATHS.LOGOUT)
+  return data
+}

--- a/src/api/queries/myInfo/useLogout.ts
+++ b/src/api/queries/myInfo/useLogout.ts
@@ -1,0 +1,8 @@
+import { logout, type LogoutResponse } from '@/api/mypage'
+import { useMutation } from '@tanstack/react-query'
+
+export const useLogout = () => {
+  return useMutation<LogoutResponse, Error>({
+    mutationFn: logout,
+  })
+}

--- a/src/constants/apisPaths.ts
+++ b/src/constants/apisPaths.ts
@@ -15,4 +15,5 @@ export const APIS_PATHS = {
   PRESIGNED_URL: '/questions/presigned-url',
   PROFILE_IMAGE: '/accounts/me/profile-image',
   CHECK_NICKNAME: '/accounts/check-nickname',
+  LOGOUT: '/accounts/logout',
 }

--- a/src/features/mypage/MyInfoView.tsx
+++ b/src/features/mypage/MyInfoView.tsx
@@ -10,6 +10,9 @@ import DeleteUserAccountModal from './delete-user/DeleteUserAccountModal'
 import { useState } from 'react'
 import { toast } from 'sonner'
 import { useDeleteMyAccount } from '@/api/queries/myInfo/useDeleteMyAccount'
+import { useQueryClient } from '@tanstack/react-query'
+import { useNavigate } from 'react-router-dom'
+import { ROUTES_PATHS } from '@/constants/routesPaths'
 
 type MyInfoViewProps = {
   myInfo: MyInfoResponse
@@ -30,21 +33,23 @@ export default function MyInfoView({
   const [isWithdrawModalOpen, setIsWithdrawModalOpen] = useState(false)
 
   const { mutate: deleteMyAccountMutate, isPending } = useDeleteMyAccount()
+  const navigate = useNavigate()
+  const queryClient = useQueryClient()
 
   const handleWithdrawSubmit = (payload: DeleteMyAccountRequest) => {
     deleteMyAccountMutate(payload, {
       onSuccess: () => {
-        toast.success('회원 탈퇴가 완료되었습니다.')
-
         setIsWithdrawModalOpen(false)
 
+        queryClient.clear()
+
+        toast.success('회원 탈퇴가 완료되었습니다.')
+
         /**
-         * TODO:
-         * - 로그아웃 처리
-         * - 토큰 제거
-         * - 메인/로그인 페이지 이동
-         * - 토스트 표시
+         * TODO: 토큰 제거
          */
+
+        navigate(ROUTES_PATHS.LOGIN_PAGE)
       },
       onError: () => {
         toast.error('회원 탈퇴에 실패했습니다.')

--- a/src/features/mypage/UserMenu.tsx
+++ b/src/features/mypage/UserMenu.tsx
@@ -1,10 +1,13 @@
 import { useState } from 'react'
 import profileViewIcon from '../../assets/icons/profileViewIcon.svg'
 import Button from '@/components/ui/button'
-import { Link } from 'react-router-dom'
+import { Link, useNavigate } from 'react-router-dom'
 import { ROUTES_PATHS } from '@/constants/routesPaths'
 import type { SelectedCourseRegisterValue } from '@/types/api-response/course'
 import CourseRegisterModal from './student-register/CourseRegisterModal'
+import { useLogout } from '@/api/queries/myInfo/useLogout'
+import { toast } from 'sonner'
+import { useGetMyInfo } from '@/api/queries/myInfo/useGetMyInfo'
 
 export default function UserMenu() {
   const [showUserMenu, setShowUserMenu] = useState(false)
@@ -15,11 +18,10 @@ export default function UserMenu() {
       courseId: null,
       cohortId: null,
     })
-  /**
-   * TODO: userData 추가 예정
-   * ex) const { data: userData } = useUser...()
-   */
-  const userData = null
+
+  const navigate = useNavigate()
+  const logoutMutation = useLogout()
+  const { data: userData } = useGetMyInfo()
 
   const handleOpenRegisterModal = () => {
     setShowUserMenu(false)
@@ -30,16 +32,43 @@ export default function UserMenu() {
     setIsRegisterModalOpen(false)
   }
 
+  const handleLogout = async () => {
+    try {
+      const result = await logoutMutation.mutateAsync()
+
+      setShowUserMenu(false)
+      toast.success(result.detail ?? '로그아웃 되었습니다.')
+
+      /**
+       * TODO: 로그인 기능 완료 후 추가
+       *
+       * 1. 필요 시 인증 상태 제거
+       * 2. 필요 시 유저 관련 캐시 제거
+       * queryClient.removeQueries({ queryKey: MY_INFO_QUERY_KEY })
+       * 3. store 정리 필요
+       * store.removeToken
+       */
+
+      navigate(ROUTES_PATHS.LOGIN_PAGE)
+    } catch {
+      toast.error('로그아웃에 실패했습니다.')
+    }
+  }
+
   return (
     <>
       <div className="relative">
         <button
-          onClick={() => setShowUserMenu(!showUserMenu)}
+          onClick={() => setShowUserMenu((prev) => !prev)}
           className="flex cursor-pointer"
         >
           <div className="h-10 w-10">
             <img
-              src={!imageError && userData ? '' : profileViewIcon}
+              src={
+                !imageError && userData?.profile_img_url
+                  ? userData.profile_img_url
+                  : profileViewIcon
+              }
               alt="유저아이콘"
               className="rounded-full"
               onError={() => {
@@ -53,14 +82,10 @@ export default function UserMenu() {
           <div className="absolute left-40 mt-6 flex -translate-x-3/4 flex-col rounded-2xl border border-gray-200 bg-white px-4 py-6 shadow-lg">
             <div className="mb-5">
               <span className="text-ui-gray-primary block text-xl font-bold">
-                {/* TODO: 유저 닉네임 */}
-                {/* {userData?.nickname} */}
-                오조오조
+                {userData?.nickname ?? '사용자'}
               </span>
               <span className="text-ui-gray-400 block text-sm font-normal">
-                {/* TODO: 유저 이메일 */}
-                {/* {userData?.email} */}
-                ozschool1234567@gmail.com
+                {userData?.email ?? ''}
               </span>
             </div>
 
@@ -83,23 +108,21 @@ export default function UserMenu() {
                 type="button"
                 variant="sidebarTab"
                 size="sidebarTab"
-                onClick={() => '/test'}
                 className="w-full rounded-none px-2 py-2.5 text-sm font-normal"
               >
                 마이페이지
               </Button>
             </Link>
-            {/**
-             * TODO: 로그아웃 기능 추가 예정
-             */}
+
             <Button
               type="button"
               variant="sidebarTab"
               size="sidebarTab"
               className="w-full rounded-none px-2 py-2.5 text-sm font-normal"
-              onClick={() => setShowUserMenu(false)}
+              onClick={handleLogout}
+              disabled={logoutMutation.isPending}
             >
-              로그아웃
+              {logoutMutation.isPending ? '로그아웃 중...' : '로그아웃'}
             </Button>
           </div>
         )}


### PR DESCRIPTION
## 📌 작업 내용

로그아웃 API 및 유저 메뉴 연동 추가
- 로그아웃 API 함수와 mutation 훅 추가
- 로그아웃 엔드포인트 상수 등록
- 유저 메뉴에서 내 정보 조회 데이터를 사용하도록 변경
- 프로필 이미지, 닉네임, 이메일 표시 및 로그아웃 처리 연동

회원 탈퇴 후 캐시 초기화 및 로그인 페이지 이동 처리
- 회원 탈퇴 성공 시 Tanstack Query 캐시 초기화
- 회원 탈퇴 완료 후 로그인 페이지로 리다이렉트

## 🔗 관련 이슈

- closes #105 

## ✅ 체크리스트

- [ ] 코드 컨벤션 확인
- [ ] lint 에러 없음
- [ ] 빌드 정상 확인
