### PR TITLE
fix: 내 정보 수정 후 my info 캐시 갱신 로직 정리

### DIFF
--- a/src/api/mypage.ts
+++ b/src/api/mypage.ts
@@ -6,8 +6,14 @@ import type {
 } from '@/types'
 import { api } from './api'
 import { APIS_PATHS } from '@/constants/apisPaths'
-import type { ChangePasswordRequest } from '@/types/api-request/myPageRequest'
-import type { ChangePasswordResponse } from '@/types/api-response/myPageResponse'
+import type {
+  ChangePasswordRequest,
+  EnrollStudentRequest,
+} from '@/types/api-request/myPageRequest'
+import type {
+  ChangePasswordResponse,
+  EnrollStudentResponse,
+} from '@/types/api-response/myPageResponse'
 import type {
   ChangePhoneRequest,
   SendPhoneVerificationCodeRequest,
@@ -25,6 +31,14 @@ export const getMyInfo = async () => {
 export const patchMyInfo = async (payload: UpdateMyInfoRequest) => {
   const { data } = await api.patch<MyInfoResponse>(
     APIS_PATHS.PATCH_MY_INFO,
+    payload
+  )
+  return data
+}
+
+export const postEnrollStudent = async (payload: EnrollStudentRequest) => {
+  const { data } = await api.post<EnrollStudentResponse>(
+    APIS_PATHS.POST_ENROLL_STUDENT,
     payload
   )
   return data

--- a/src/api/queries/enrolled-student/usePostEnrollStudent.ts
+++ b/src/api/queries/enrolled-student/usePostEnrollStudent.ts
@@ -1,0 +1,24 @@
+import { postEnrollStudent } from '@/api/mypage'
+import type { EnrollStudentRequest } from '@/types/api-request/myPageRequest'
+import type {
+  EnrollStudentResponse,
+  ErrorDetailResponse,
+} from '@/types/api-response/myPageResponse'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { MY_ENROLLED_COURSES_QUERY_KEY } from './useGetMyEnrolledCourses'
+
+export const usePostEnrollStudent = () => {
+  const queryClient = useQueryClient()
+  return useMutation<
+    EnrollStudentResponse,
+    ErrorDetailResponse,
+    EnrollStudentRequest
+  >({
+    mutationFn: postEnrollStudent,
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: MY_ENROLLED_COURSES_QUERY_KEY,
+      })
+    },
+  })
+}

--- a/src/api/queries/myInfo/usePatchMyInfo.ts
+++ b/src/api/queries/myInfo/usePatchMyInfo.ts
@@ -1,7 +1,6 @@
 import { patchMyInfo } from '@/api/mypage'
 import type { UpdateMyInfoRequest } from '@/types'
 import { useMutation, useQueryClient } from '@tanstack/react-query'
-import { MY_ENROLLED_COURSES_QUERY_KEY } from '../enrolled-student/useGetMyEnrolledCourses'
 import { MY_INFO_QUERY_KEY } from './useGetMyInfo'
 
 export const usePatchMyInfo = () => {
@@ -9,9 +8,8 @@ export const usePatchMyInfo = () => {
 
   return useMutation({
     mutationFn: (payload: UpdateMyInfoRequest) => patchMyInfo(payload),
-    onSuccess: (updatedData) => {
-      queryClient.setQueryData(MY_INFO_QUERY_KEY, updatedData)
-      queryClient.invalidateQueries({ queryKey: MY_ENROLLED_COURSES_QUERY_KEY })
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({ queryKey: MY_INFO_QUERY_KEY })
     },
   })
 }

--- a/src/constants/apisPaths.ts
+++ b/src/constants/apisPaths.ts
@@ -8,6 +8,7 @@ export const APIS_PATHS = {
   PATCH_MY_INFO: '/accounts/me',
   DELETE_MY_ACCOUNT: '/accounts/me',
   GET_MY_ENROLLED_COURSES: '/accounts/me/enrolled-courses',
+  POST_ENROLL_STUDENT: '/accounts/enroll-student',
   AVAILABLE_COURSES: '/accounts/available-courses',
   CHANGE_PASSWORD: '/accounts/change-password',
   PHONE_VERIFICATION_SEND: '/accounts/verification/send-sms',

--- a/src/constants/initialRegisterValue.ts
+++ b/src/constants/initialRegisterValue.ts
@@ -1,0 +1,6 @@
+import type { SelectedCourseRegisterValue } from '@/types/api-response/course'
+
+export const INITIAL_REGISTER_VALUE: SelectedCourseRegisterValue = {
+  courseId: null,
+  cohortId: null,
+}

--- a/src/features/mypage/UserMenu.tsx
+++ b/src/features/mypage/UserMenu.tsx
@@ -8,16 +8,14 @@ import CourseRegisterModal from './student-register/CourseRegisterModal'
 import { useLogout } from '@/api/queries/myInfo/useLogout'
 import { toast } from 'sonner'
 import { useGetMyInfo } from '@/api/queries/myInfo/useGetMyInfo'
+import { INITIAL_REGISTER_VALUE } from '@/constants/initialRegisterValue'
 
 export default function UserMenu() {
   const [showUserMenu, setShowUserMenu] = useState(false)
   const [imageError, setImageError] = useState(false)
   const [isRegisterModalOpen, setIsRegisterModalOpen] = useState(false)
   const [selectedRegisterValue, setSelectedRegisterValue] =
-    useState<SelectedCourseRegisterValue>({
-      courseId: null,
-      cohortId: null,
-    })
+    useState<SelectedCourseRegisterValue>(INITIAL_REGISTER_VALUE)
 
   const navigate = useNavigate()
   const logoutMutation = useLogout()
@@ -25,11 +23,13 @@ export default function UserMenu() {
 
   const handleOpenRegisterModal = () => {
     setShowUserMenu(false)
+    setSelectedRegisterValue(INITIAL_REGISTER_VALUE)
     setIsRegisterModalOpen(true)
   }
 
   const handleCloseRegisterModal = () => {
     setIsRegisterModalOpen(false)
+    setSelectedRegisterValue(INITIAL_REGISTER_VALUE)
   }
 
   const handleLogout = async () => {
@@ -57,7 +57,7 @@ export default function UserMenu() {
 
   return (
     <>
-      <div className="relative">
+      <div className="relative inline-block">
         <button
           onClick={() => setShowUserMenu((prev) => !prev)}
           className="flex cursor-pointer"
@@ -79,12 +79,12 @@ export default function UserMenu() {
         </button>
 
         {showUserMenu && (
-          <div className="absolute left-40 mt-6 flex -translate-x-3/4 flex-col rounded-2xl border border-gray-200 bg-white px-4 py-6 shadow-lg">
+          <div className="absolute top-full left-0 z-50 mt-7 flex flex-col rounded-2xl border border-gray-200 bg-white px-4 py-6 shadow-lg">
             <div className="mb-5">
               <span className="text-ui-gray-primary block text-xl font-bold">
                 {userData?.nickname ?? '사용자'}
               </span>
-              <span className="text-ui-gray-400 block text-sm font-normal">
+              <span className="text-ui-gray-400 block text-sm font-normal break-all">
                 {userData?.email ?? ''}
               </span>
             </div>

--- a/src/features/mypage/student-register/CourseRegisterModal.tsx
+++ b/src/features/mypage/student-register/CourseRegisterModal.tsx
@@ -4,6 +4,8 @@ import Modal from '@/components/ui/modal/Modal'
 import type { SelectedCourseRegisterValue } from '@/types/api-response/course'
 import CourseRegisterFields from './CourseRegisterFields'
 import { cn } from '@/lib/utils'
+import { usePostEnrollStudent } from '@/api/queries/enrolled-student/usePostEnrollStudent'
+import { toast } from 'sonner'
 
 type CourseRegisterModalProps = {
   isOpen: boolean
@@ -24,7 +26,30 @@ export default function CourseRegisterModal({
   onImageError,
 }: CourseRegisterModalProps) {
   const isSubmitDisabled = !value.courseId || !value.cohortId
+  const { mutate, isPending } = usePostEnrollStudent()
 
+  const handleSubmit = () => {
+    if (!value.cohortId) {
+      return
+    }
+
+    mutate(
+      { cohort_id: value.cohortId },
+      {
+        onSuccess: (res) => {
+          toast.success(res.detail)
+          onClose()
+        },
+        onError: (err) => {
+          const errorMsg =
+            typeof err.error_detail === 'string'
+              ? err.error_detail
+              : '등록에 실패했습니다.'
+          toast.error(errorMsg)
+        },
+      }
+    )
+  }
   return (
     <Modal isOpen={isOpen} onClose={onClose}>
       <div className="w-99 p-6">
@@ -59,10 +84,10 @@ export default function CourseRegisterModal({
             `h-13 rounded-lg p-2 text-base font-normal`,
             isSubmitDisabled ? 'cursor-not-allowed' : ''
           )}
-          onClick={onClose}
+          onClick={handleSubmit}
           disabled={isSubmitDisabled}
         >
-          등록하기
+          {isPending ? '등록중...' : '등록하기'}
         </Button>
       </div>
     </Modal>

--- a/src/types/api-request/myPageRequest.ts
+++ b/src/types/api-request/myPageRequest.ts
@@ -24,3 +24,7 @@ export type ChangePasswordRequest = {
   old_password: string
   new_password: string
 }
+
+export type EnrollStudentRequest = {
+  cohort_id: number
+}

--- a/src/types/api-response/myPageResponse.ts
+++ b/src/types/api-response/myPageResponse.ts
@@ -30,6 +30,10 @@ export type EnrolledCourseResponse = {
   }
 }
 
+export type EnrollStudentResponse = {
+  detail: string
+}
+
 export type ChangePasswordResponse = {
   detail: string
 }


### PR DESCRIPTION
## 📌 작업 내용

내 정보 수정 후 my info 캐시 갱신 로직 정리
- usePatchMyInfo 성공 시 내 정보 쿼리 갱신하도록 수정

마이페이지 수강생 등록 API 연동 및 모달 상태 개선
- 수강생 등록 API 경로와 요청/응답 타입 추가
- 수강생 등록 mutation hook 구현 및 등록 후 수강 목록 갱신 처리
- CourseRegisterModal 등록 버튼에 실제 등록 요청과 성공/실패 토스트 연결
- UserMenu에서 등록 모달 열기/닫기 시 초기값 복원하도록 수정

## 🔗 관련 이슈

- closes #109 

## ✅ 체크리스트

- [ ] 코드 컨벤션 확인
- [ ] lint 에러 없음
- [ ] 빌드 정상 확인
