### PR TITLE
feat: 쪽지시험 목록조회 api 연결

### DIFF
--- a/src/features/mypage/MyExamTab.tsx
+++ b/src/features/mypage/MyExamTab.tsx
@@ -18,12 +18,28 @@ import type {
 import { useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 
-type ExamItem = ExamDeploymentItem
+const getExamImageSrc = (item: ExamDeploymentItem | null) => {
+  if (!item) {
+    return ''
+  }
+  const subjectIcon =
+    EXAM_SUBJECT_ICON_MAP[
+      item.exam.subject.title as keyof typeof EXAM_SUBJECT_ICON_MAP
+    ]
+  return (
+    subjectIcon ??
+    item.exam.subject.thumbnail_img_url ??
+    item.exam.thumbnail_img_url ??
+    ''
+  )
+}
 
 export default function MyExamTab() {
   const navigate = useNavigate()
   const [activeTab, setActiveTab] = useState<ExamTabType>('all')
-  const [selectedExam, setSelectedExam] = useState<ExamItem | null>(null)
+  const [selectedExam, setSelectedExam] = useState<ExamDeploymentItem | null>(
+    null
+  )
   const [isEntryCodeModalOpen, setIsEntryCodeModalOpen] = useState(false)
   const { data, isPending, isError } = useExamDeployments()
   const examList = data?.results ?? []
@@ -35,13 +51,15 @@ export default function MyExamTab() {
     return item.exam_info.status === activeTab
   })
 
-  const handleExamActionClick = (item: ExamItem) => {
-    const status = item.exam_info.status as keyof typeof EXAM_STATUS_META
+  const handleExamActionClick = (item: ExamDeploymentItem) => {
+    const status = item.exam_info.status
     const isDone = status === 'done'
-    if (isDone) {
-      navigate(getQuizResultPage(item.id))
+
+    if (isDone && item.submission_id) {
+      navigate(getQuizResultPage(item.submission_id))
       return
     }
+
     setSelectedExam(item)
     setIsEntryCodeModalOpen(true)
   }
@@ -50,11 +68,14 @@ export default function MyExamTab() {
     setIsEntryCodeModalOpen(false)
     setSelectedExam(null)
   }
+
   const { mutateAsync: checkCode } = useCheckExamCode()
+
   const handleConfirmEntryCode = async (entryCode: string) => {
     if (!selectedExam) {
       return false
     }
+
     try {
       await checkCode({
         deploymentId: selectedExam.id,
@@ -66,17 +87,8 @@ export default function MyExamTab() {
       return false
     }
   }
-  const selectedSubjectTitle = selectedExam?.exam.subject.title as
-    | keyof typeof EXAM_SUBJECT_ICON_MAP
-    | undefined
 
-  const modalImageSrc =
-    (selectedSubjectTitle
-      ? EXAM_SUBJECT_ICON_MAP[selectedSubjectTitle]
-      : undefined) ??
-    selectedExam?.exam.subject.thumbnail_img_url ??
-    selectedExam?.exam.thumbnail_img_url ??
-    ''
+  const modalImageSrc = getExamImageSrc(selectedExam)
 
   if (isPending) {
     return <div>로딩 중...</div>
@@ -132,13 +144,7 @@ export default function MyExamTab() {
           ) : (
             <ul className="flex flex-col gap-4">
               {filteredExamList.map((item) => {
-                const subjectTitle = item.exam.subject
-                  .title as keyof typeof EXAM_SUBJECT_ICON_MAP
-                const subjectIcon =
-                  EXAM_SUBJECT_ICON_MAP[subjectTitle] ??
-                  item.exam.subject.thumbnail_img_url ??
-                  item.exam.thumbnail_img_url ??
-                  ''
+                const subjectIcon = getExamImageSrc(item)
                 const status = item.exam_info.status
                 const statusMeta = EXAM_STATUS_META[status]
                 const isDone = status === 'done'

--- a/src/mocks/handlers/examHandlers.ts
+++ b/src/mocks/handlers/examHandlers.ts
@@ -2,13 +2,12 @@ import { API_BASE_URL } from '@/constants/apisPaths'
 import type { ExamStatusResponse } from '@/types/quizpage-type/status'
 import { http, HttpResponse } from 'msw'
 import { mockQuizData } from '../data/examData'
-import { mockExamDeploymentList } from '../data/mockExamDeploymentList'
 
 export const examHandlers = [
-  // 시험 목록 조회
-  http.get(`${API_BASE_URL}/exams/deployments`, () => {
-    return HttpResponse.json(mockExamDeploymentList, { status: 200 })
-  }),
+  // // 시험 목록 조회
+  // http.get(`${API_BASE_URL}/exams/deployments`, () => {
+  //   return HttpResponse.json(mockExamDeploymentList, { status: 200 })
+  // }),
 
   // 시험 문제 조회
   http.get(`${API_BASE_URL}/exams/deployments/:deploymentId`, ({ params }) => {

--- a/src/types/mypage-type/examDeployment.ts
+++ b/src/types/mypage-type/examDeployment.ts
@@ -1,25 +1,32 @@
 export type ExamTabType = 'all' | 'done' | 'pending'
 export type ExamStatus = 'done' | 'pending'
+
+export type ExamSubject = {
+  id: number
+  title: string
+  thumbnail_img_url: string | null
+}
+
+export type ExamInfo = {
+  status: ExamStatus
+  score: number | null
+  correct_answer_count: number | null
+}
+
+export type ExamSummary = {
+  id: number
+  title: string
+  thumbnail_img_url: string
+  subject: ExamSubject
+}
+
 export type ExamDeploymentItem = {
   id: number
   submission_id: number | null
-  exam: {
-    id: number
-    title: string
-    thumbnail_img_url: string
-    subject: {
-      id: number
-      title: string
-      thumbnail_img_url: string | null
-    }
-  }
+  exam: ExamSummary
   question_count: number
   total_score: number
-  exam_info: {
-    status: ExamStatus
-    score: number | null
-    correct_answer_count: number | null
-  }
+  exam_info: ExamInfo
   is_done: boolean
   duration_time: number
 }


### PR DESCRIPTION
## 📌 작업 내용

- 쪽지시험 목록조회 API 연결
- mock 핸들러 제거
- api 필드값에 맞춰 변경

## 🔗 관련 이슈

- closes #118 

## 📸 스크린샷 (선택)
<img width="1025" height="847" alt="스크린샷 2026-03-26 134116" src="https://github.com/user-attachments/assets/5de3189c-4647-488d-8d56-a2080491e3ae" />
<img width="1459" height="483" alt="스크린샷 2026-03-26 134131" src="https://github.com/user-attachments/assets/ee786fef-5954-45dc-90b9-07d7ab9038bf" />

## ✅ 체크리스트

- [ ] 코드 컨벤션 확인
- [ ] lint 에러 없음
- [ ] 빌드 정상 확인
