### PR TITLE
feat: 참가코드 검증 API 연결

### DIFF
--- a/src/components/exam/ExamEntryCodeModal.tsx
+++ b/src/components/exam/ExamEntryCodeModal.tsx
@@ -1,36 +1,36 @@
-import { useEffect, useId, useState } from 'react'
-
+import { useCheckExamCode } from '@/api/queries/exam/useCheckExamCode'
 import Button from '@/components/ui/button'
 import Modal from '@/components/ui/modal/Modal'
+import { useEffect, useId, useState } from 'react'
 import Input from '../ui/input'
 
 type ExamEntryCodeModalProps = {
   isOpen: boolean
+  deploymentId: number
   examTitle: string
   questionCount: number
   timeLimit: number
   imageSrc: string
   imageAlt?: string
   onClose: () => void
-  onConfirm: (code: string) => boolean | Promise<boolean>
 }
 
 export default function ExamEntryCodeModal({
   isOpen,
+  deploymentId,
   examTitle,
   questionCount,
   timeLimit,
   imageSrc,
   imageAlt = '',
   onClose,
-  onConfirm,
 }: ExamEntryCodeModalProps) {
   const [entryCode, setEntryCode] = useState('')
   const [errorMessage, setErrorMessage] = useState('')
-
   const inputId = useId()
   const descriptionId = useId()
   const errorId = useId()
+  const { mutateAsync: checkExamCode, isPending } = useCheckExamCode()
 
   useEffect(() => {
     if (!isOpen) {
@@ -41,22 +41,25 @@ export default function ExamEntryCodeModal({
 
   const handleChangeEntryCode = (value: string) => {
     setEntryCode(value)
-
     if (errorMessage) {
       setErrorMessage('')
     }
   }
+
   const handleSubmit = async () => {
     const trimmedCode = entryCode.trim()
-
     if (!trimmedCode) {
-      setErrorMessage('참가코드를 입력해 주세요.')
+      setErrorMessage('*참가코드를 입력해 주세요.')
       return
     }
-
-    const isValid = await onConfirm(trimmedCode)
-
-    if (!isValid) {
+    try {
+      await checkExamCode({
+        deploymentId,
+        entryCode: trimmedCode,
+      })
+      setErrorMessage('')
+      onClose()
+    } catch {
       setErrorMessage('*코드번호가 일치하지 않습니다.')
     }
   }
@@ -65,7 +68,6 @@ export default function ExamEntryCodeModal({
     setErrorMessage('')
     onClose()
   }
-
   return (
     <Modal isOpen={isOpen} onClose={handleClose}>
       <section className="mx-6 mt-2.5 mb-6">

--- a/src/components/exam/ExamEntryCodeModal.tsx
+++ b/src/components/exam/ExamEntryCodeModal.tsx
@@ -13,6 +13,7 @@ type ExamEntryCodeModalProps = {
   imageSrc: string
   imageAlt?: string
   onClose: () => void
+  onSuccess: () => void
 }
 
 export default function ExamEntryCodeModal({
@@ -24,6 +25,7 @@ export default function ExamEntryCodeModal({
   imageSrc,
   imageAlt = '',
   onClose,
+  onSuccess,
 }: ExamEntryCodeModalProps) {
   const [entryCode, setEntryCode] = useState('')
   const [errorMessage, setErrorMessage] = useState('')
@@ -58,16 +60,18 @@ export default function ExamEntryCodeModal({
         entryCode: trimmedCode,
       })
       setErrorMessage('')
-      onClose()
+      onSuccess()
     } catch {
       setErrorMessage('*코드번호가 일치하지 않습니다.')
     }
   }
+
   const handleClose = () => {
     setEntryCode('')
     setErrorMessage('')
     onClose()
   }
+
   return (
     <Modal isOpen={isOpen} onClose={handleClose}>
       <section className="mx-6 mt-2.5 mb-6">
@@ -125,8 +129,12 @@ export default function ExamEntryCodeModal({
             ) : null}
           </div>
 
-          <Button type="submit" className="mt-6 w-full rounded-[4px]">
-            시험시작
+          <Button
+            type="submit"
+            className="mt-6 w-full rounded-[4px]"
+            disabled={isPending}
+          >
+            {isPending ? '확인 중...' : '시험시작'}
           </Button>
         </form>
       </section>

--- a/src/features/mypage/MyExamTab.tsx
+++ b/src/features/mypage/MyExamTab.tsx
@@ -210,9 +210,9 @@ export default function MyExamTab() {
           )}
         </div>
       </section>
-
       <ExamEntryCodeModal
         isOpen={isEntryCodeModalOpen}
+        deploymentId={selectedExam?.id ?? 0}
         examTitle={selectedExam?.exam.title ?? ''}
         questionCount={selectedExam?.question_count ?? 0}
         timeLimit={selectedExam?.duration_time ?? 20}
@@ -221,7 +221,6 @@ export default function MyExamTab() {
           selectedExam ? `${selectedExam.exam.subject.title} 과목 아이콘` : ''
         }
         onClose={handleCloseEntryCodeModal}
-        onConfirm={handleConfirmEntryCode}
       />
     </>
   )

--- a/src/features/mypage/MyExamTab.tsx
+++ b/src/features/mypage/MyExamTab.tsx
@@ -1,4 +1,3 @@
-import { useCheckExamCode } from '@/api/queries/exam/useCheckExamCode'
 import { useExamDeployments } from '@/api/queries/exam/useExamDeployments'
 import ExamEmptyState from '@/components/exam/ExamEmptyState'
 import ExamEntryCodeModal from '@/components/exam/ExamEntryCodeModal'
@@ -54,12 +53,10 @@ export default function MyExamTab() {
   const handleExamActionClick = (item: ExamDeploymentItem) => {
     const status = item.exam_info.status
     const isDone = status === 'done'
-
     if (isDone && item.submission_id) {
       navigate(getQuizResultPage(item.submission_id))
       return
     }
-
     setSelectedExam(item)
     setIsEntryCodeModalOpen(true)
   }
@@ -69,23 +66,12 @@ export default function MyExamTab() {
     setSelectedExam(null)
   }
 
-  const { mutateAsync: checkCode } = useCheckExamCode()
-
-  const handleConfirmEntryCode = async (entryCode: string) => {
+  const handleSuccessEntryCode = () => {
     if (!selectedExam) {
-      return false
+      return
     }
-
-    try {
-      await checkCode({
-        deploymentId: selectedExam.id,
-        entryCode,
-      })
-      navigate(getQuizPage(selectedExam.id))
-      return true
-    } catch {
-      return false
-    }
+    handleCloseEntryCodeModal()
+    navigate(getQuizPage(selectedExam.id))
   }
 
   const modalImageSrc = getExamImageSrc(selectedExam)
@@ -221,6 +207,7 @@ export default function MyExamTab() {
           selectedExam ? `${selectedExam.exam.subject.title} 과목 아이콘` : ''
         }
         onClose={handleCloseEntryCodeModal}
+        onSuccess={handleSuccessEntryCode}
       />
     </>
   )

--- a/src/mocks/handlers/examHandlers.ts
+++ b/src/mocks/handlers/examHandlers.ts
@@ -23,30 +23,30 @@ export const examHandlers = [
   }),
 
   // 참가 코드 검증
-  http.post(
-    `${API_BASE_URL}/exams/deployments/:deploymentId/check-code`,
-    async ({ request, params }) => {
-      const body = (await request.json()) as { code?: string }
-      const { deploymentId } = params
+  // http.post(
+  //   `${API_BASE_URL}/exams/deployments/:deploymentId/check-code`,
+  //   async ({ request, params }) => {
+  //     const body = (await request.json()) as { code?: string }
+  //     const { deploymentId } = params
 
-      if (body.code === '1234') {
-        return HttpResponse.json(
-          {
-            message: '참가 코드가 확인되었습니다.',
-            deployment_id: Number(deploymentId),
-          },
-          { status: 200 }
-        )
-      }
+  //     if (body.code === '1234') {
+  //       return HttpResponse.json(
+  //         {
+  //           message: '참가 코드가 확인되었습니다.',
+  //           deployment_id: Number(deploymentId),
+  //         },
+  //         { status: 200 }
+  //       )
+  //     }
 
-      return HttpResponse.json(
-        {
-          message: '참가 코드가 올바르지 않습니다.',
-        },
-        { status: 400 }
-      )
-    }
-  ),
+  //     return HttpResponse.json(
+  //       {
+  //         message: '참가 코드가 올바르지 않습니다.',
+  //       },
+  //       { status: 400 }
+  //     )
+  //   }
+  // ),
 
   // 응시 상태 확인
   http.get(


### PR DESCRIPTION
## 📌 작업 내용

- 참가코드 검증 API를 모달에 연결했습니다.
- 사용하지 않는 참가코드 검증 핸들러와 관련 코드를 정리했습니다.

## 🔗 관련 이슈

- closes #108 

## 📸 스크린샷 (선택)
<img width="737" height="505" alt="스크린샷 2026-03-26 142137" src="https://github.com/user-attachments/assets/48634705-32a2-41b8-b8fe-04b6d40af448" />

## ✅ 체크리스트

- [ ] 코드 컨벤션 확인
- [ ] lint 에러 없음
- [ ] 빌드 정상 확인
