### PR TITLE
feat: 아이디 찾기 API 연동 및 로그인 화면 개선

### DIFF
--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -1,6 +1,10 @@
 import { api } from './api'
 import { APIS_PATHS } from '@/constants/apisPaths'
 import type {
+  FindEmailRequest,
+  FindEmailResponse,
+} from '@/types/auth-type/findEmail'
+import type {
   loginRequest,
   loginSuccessResponse,
 } from '@/types/auth-type/login'
@@ -10,6 +14,15 @@ export const postLogin = async (
 ): Promise<loginSuccessResponse> => {
   const { data } = await api.post<loginSuccessResponse>(
     APIS_PATHS.POST_LOGIN,
+    payload
+  )
+
+  return data
+}
+
+export const postFindEmail = async (payload: FindEmailRequest) => {
+  const { data } = await api.post<FindEmailResponse>(
+    APIS_PATHS.FIND_EMAIL,
     payload
   )
 

--- a/src/api/queries/auth/useFindEmail.ts
+++ b/src/api/queries/auth/useFindEmail.ts
@@ -1,0 +1,9 @@
+import { postFindEmail } from '@/api/auth'
+import type { FindEmailRequest } from '@/types/auth-type/findEmail'
+import { useMutation } from '@tanstack/react-query'
+
+export const useFindEmail = () => {
+  return useMutation({
+    mutationFn: (payload: FindEmailRequest) => postFindEmail(payload),
+  })
+}

--- a/src/constants/apisPaths.ts
+++ b/src/constants/apisPaths.ts
@@ -14,12 +14,13 @@ export const APIS_PATHS = {
   PHONE_VERIFICATION_SEND: '/accounts/verification/send-sms',
   PHONE_VERIFICATION_VERIFY: '/accounts/verification/verify-sms',
   CHANGE_PHONE: '/accounts/change-phone',
-  PRESIGNED_URL: '/questions/presigned-url',
+  PRESIGNED_URL: '/accounts/me/profile-image/presigned-url',
   PROFILE_IMAGE: '/accounts/me/profile-image',
   CHECK_NICKNAME: '/accounts/check-nickname',
   LOGOUT: '/accounts/logout',
   REFRESH_TOKEN: '/accounts/me/refresh',
 
+  FIND_EMAIL: '/accounts/find-email',
   GET_EXAM_DEPLOYMENTS: '/exams/deployments',
   GET_EXAM_RESULT: '/exams/submissions',
 }

--- a/src/features/auth/find-id/FindIdModal.tsx
+++ b/src/features/auth/find-id/FindIdModal.tsx
@@ -44,12 +44,12 @@ const FindIdModal = ({
 
   const renderInputContent = () => {
     return (
-      <div className="flex flex-col gap-[32px] px-[24px] pb-[24px]">
-        <div className="flex flex-col items-center gap-[16px] text-center">
-          <FindIdIconSvg className="h-[28px] w-[28px]" />
+      <div className="flex flex-col gap-8 px-6 pb-6">
+        <div className="flex flex-col items-center gap-4 text-center">
+          <FindIdIconSvg className="h-7 w-7" />
 
-          <div className="flex flex-col items-center gap-[12px]">
-            <h2 className="text-ui-gray-primary text-[20px] leading-[140%] font-bold tracking-[-0.03em]">
+          <div className="flex flex-col items-center gap-3">
+            <h2 className="text-ui-gray-primary text-xl leading-[140%] font-bold tracking-[-0.03em]">
               아이디 찾기
             </h2>
 
@@ -61,11 +61,11 @@ const FindIdModal = ({
           </div>
         </div>
 
-        <div className="flex flex-col gap-[32px]">
-          <div className="flex flex-col gap-[12px]">
+        <div className="flex flex-col gap-8">
+          <div className="flex flex-col gap-3">
             <label
               htmlFor="find-id-name"
-              className="text-ui-gray-primary text-[16px] leading-[140%] font-normal tracking-[-0.03em]"
+              className="text-ui-gray-primary text-base leading-[140%] font-normal tracking-[-0.03em]"
             >
               이름<span className="text-other-red">*</span>
             </label>
@@ -76,7 +76,7 @@ const FindIdModal = ({
               value={name}
               onChange={(e) => handleNameChange(e.target.value)}
               placeholder="이름을 입력해주세요"
-              className="h-[48px]"
+              className="h-12"
             />
           </div>
 
@@ -106,7 +106,7 @@ const FindIdModal = ({
         <Button
           variant="fill"
           size="full"
-          className="!h-[52px] !rounded-[4px] !p-0"
+          className="h-13 rounded-lg p-0"
           onClick={handleFindId}
         >
           아이디 찾기
@@ -117,32 +117,32 @@ const FindIdModal = ({
 
   const renderResultContent = () => {
     return (
-      <div className="flex flex-col gap-[32px] px-[24px] pb-[24px]">
-        <div className="flex flex-col items-center gap-[16px] text-center">
-          <FindIdIconSvg className="h-[28px] w-[28px]" />
+      <div className="flex flex-col gap-8 px-6 pb-6">
+        <div className="flex flex-col items-center gap-4 text-center">
+          <FindIdIconSvg className="h-7 w-7" />
 
-          <div className="flex flex-col items-center gap-[12px]">
-            <h2 className="text-ui-gray-primary text-[20px] leading-[140%] font-bold tracking-[-0.03em]">
+          <div className="flex flex-col items-center gap-3">
+            <h2 className="text-ui-gray-primary text-xl leading-[140%] font-bold tracking-[-0.03em]">
               아이디 찾기
             </h2>
 
-            <p className="text-ui-gray-600 text-[14px] leading-[140%] font-normal tracking-[-0.03em]">
+            <p className="text-ui-gray-600 text-sm leading-[140%] font-normal tracking-[-0.03em]">
               입력하신 정보와 일치하는 아이디입니다.
             </p>
           </div>
         </div>
 
-        <div className="border-ui-gray-disabled bg-ui-gray-200 flex items-center justify-center rounded-[4px] border px-[16px] py-[20px]">
-          <span className="text-ui-gray-primary text-[18px] leading-[140%] font-semibold tracking-[-0.03em]">
+        <div className="border-ui-gray-disabled bg-ui-gray-200 flex items-center justify-center rounded-lg border px-4 py-5">
+          <span className="text-ui-gray-primary text-lg leading-[140%] font-semibold tracking-[-0.03em]">
             {maskedEmail}
           </span>
         </div>
 
-        <div className="flex gap-[12px]">
+        <div className="flex gap-3">
           <Button
             variant="outline"
             size="full"
-            className="!h-[48px] !rounded-[4px] !bg-white !p-0"
+            className="h-12 rounded-lg bg-white p-0"
             onClick={onClose}
           >
             로그인
@@ -151,7 +151,7 @@ const FindIdModal = ({
           <Button
             variant="fill"
             size="full"
-            className="!h-[48px] !rounded-[4px] !p-0"
+            className="h-12 rounded-lg p-0"
             onClick={() => {
               onClose()
               onFindPassword()

--- a/src/features/auth/login/LoginForm.tsx
+++ b/src/features/auth/login/LoginForm.tsx
@@ -29,30 +29,34 @@ const LoginForm = ({ onSubmit, onFindId, onFindPassword }: LoginFormProps) => {
   }
 
   return (
-    <div className="flex w-full flex-col gap-[12px]">
+    <div className="flex w-full flex-col gap-3">
       <InputField
         type="email"
         placeholder="아이디 (example@gmail.com)"
         value={email}
         onChange={(e) => setEmail(e.target.value)}
-        className="border-ui-gray-disabled placeholder:text-ui-gray-disabled h-[48px] rounded-[4px] px-[16px] py-[10px] text-[14px] leading-[17px] tracking-[-0.03em]"
+        className="border-ui-gray-disabled placeholder:text-ui-gray-disabled h-12 rounded-lg px-4 py-2.5 text-[14px] leading-[17px] tracking-[-0.03em]"
       />
 
-      <div className="flex w-full flex-col gap-[8px]">
+      <div className="flex w-full flex-col gap-2">
         <InputField
           type="password"
           placeholder="비밀번호 (6~15자의 영문 대소문자, 숫자, 특수문자 포함)"
           value={password}
           onChange={(e) => setPassword(e.target.value)}
-          className="border-ui-gray-disabled placeholder:text-ui-gray-disabled h-[48px] rounded-[4px] px-[16px] py-[10px] pr-[44px] text-[14px] leading-[17px] tracking-[-0.03em]"
+          className="border-ui-gray-disabled placeholder:text-ui-gray-disabled h-12 rounded-lg px-4 py-2.5 pr-11 text-[14px] leading-[17px] tracking-[-0.03em]"
         />
 
         <div className="text-ui-gray-600 flex items-center text-[14px] leading-[140%] tracking-[-0.03em]">
-          <button type="button" onClick={onFindId}>
+          <button type="button" onClick={onFindId} className="cursor-pointer">
             아이디 찾기
           </button>
-          <span className="px-[8px]">|</span>
-          <button type="button" onClick={onFindPassword}>
+          <span className="px-2">|</span>
+          <button
+            type="button"
+            onClick={onFindPassword}
+            className="cursor-pointer"
+          >
             비밀번호 찾기
           </button>
         </div>
@@ -63,7 +67,7 @@ const LoginForm = ({ onSubmit, onFindId, onFindPassword }: LoginFormProps) => {
         onClick={handleLoginBtnClick}
         disabled={isDisabled}
         className={cn(
-          'h-[52px] w-full rounded-[4px] p-0 text-[16px] leading-[140%] tracking-[-0.03em]',
+          'h-13 w-full rounded-lg p-0 text-[16px] leading-[140%] tracking-[-0.03em]',
           isDisabled
             ? 'bg-ui-gray-200 text-ui-gray-disabled cursor-not-allowed'
             : 'bg-primary-default hover:bg-primary-600 active:bg-primary-700 text-white'

--- a/src/features/mypage/EnrolledCourseCard.tsx
+++ b/src/features/mypage/EnrolledCourseCard.tsx
@@ -18,14 +18,12 @@ export default function EnrolledCourseCard({
         </p>
       </div>
 
-      <div className="h-25 w-38 rounded-md bg-gray-100">
-        {course.course.thumbnail_img_url ? (
-          <img
-            src={course.course.thumbnail_img_url}
-            alt={course.course.name}
-            className="h-full w-full object-cover"
-          />
-        ) : null}
+      <div className="mb-2 h-25 w-38 rounded-md bg-gray-100">
+        <img
+          src={course.course.thumbnail_img_url}
+          alt={course.course.name}
+          className="h-full w-full object-cover"
+        />
       </div>
     </div>
   )

--- a/src/features/mypage/MyInfoEdit.tsx
+++ b/src/features/mypage/MyInfoEdit.tsx
@@ -100,9 +100,7 @@ export default function MyInfoEdit({
        */
       if (verifiedPhoneToken) {
         const result = await changePhoneMutation.mutateAsync({
-          phone_verify_token: {
-            token: verifiedPhoneToken,
-          },
+          phone_verify_token: verifiedPhoneToken,
         })
 
         setPhoneNumber(result.phone_number)

--- a/src/features/mypage/UserMenu.tsx
+++ b/src/features/mypage/UserMenu.tsx
@@ -70,7 +70,7 @@ export default function UserMenu() {
                   : profileViewIcon
               }
               alt="유저아이콘"
-              className="rounded-full"
+              className="h-10 w-10 rounded-full"
               onError={() => {
                 setImageError(true)
               }}

--- a/src/features/mypage/delete-user/DeleteUserAccountModal.tsx
+++ b/src/features/mypage/delete-user/DeleteUserAccountModal.tsx
@@ -49,7 +49,7 @@ export default function DeleteUserAccountModal({
   }
 
   return (
-    <Modal isOpen={isOpen} onClose={onClose}>
+    <Modal isOpen={isOpen} onClose={onClose} width="w-[646px]">
       <div className="w-161.5 rounded-2xl bg-white p-6">
         <div className="text-ui-gray-primary mb-10 text-xl font-bold">
           오즈코딩스쿨을 탈퇴하시는 이유는 무엇인가요?

--- a/src/hooks/useFindId.ts
+++ b/src/hooks/useFindId.ts
@@ -7,10 +7,14 @@ export type FindIdStep = 'input' | 'result'
 
 export type FindIdHandlers = {
   onSendCode: (params: { name: string; phone: string }) => Promise<void> | void
-  onVerifyCode: (params: { code: string }) => Promise<void> | void
+  onVerifyCode: (params: {
+    phone: string
+    code: string
+  }) => Promise<void> | void
   onFindId: (params: {
     name: string
     phone: string
+    code: string
   }) => Promise<{ maskedEmail: string }> | { maskedEmail: string }
 }
 
@@ -119,7 +123,7 @@ export const useFindId = ({ isOpen, handlers }: UseFindIdParams) => {
     }
 
     try {
-      await handlers.onVerifyCode({ code })
+      await handlers.onVerifyCode({ phone, code })
       markCodeVerified()
       setFindErrorMessage('')
     } catch (error) {
@@ -137,12 +141,15 @@ export const useFindId = ({ isOpen, handlers }: UseFindIdParams) => {
       return
     }
 
+    /**
+     * TODO: 이메일 찾기에 검증 로직을 제외하려면 if문 주석처리
+     */
     if (!validateBeforeSubmit()) {
       return
     }
 
     try {
-      const result = await handlers.onFindId({ name, phone })
+      const result = await handlers.onFindId({ name, phone, code })
       setFindErrorMessage('')
       setMaskedEmail(result.maskedEmail)
       setStep('result')

--- a/src/hooks/usePhoneVerifySection.ts
+++ b/src/hooks/usePhoneVerifySection.ts
@@ -178,7 +178,7 @@ export default function usePhoneNumberVerificationSection({
       markCodeVerified()
       setPhoneEditStep('verified')
       setVerificationStatus('success')
-      onVerifiedTokenChange(result.token)
+      onVerifiedTokenChange(result.sms_token)
       toast.success('휴대전화 인증이 완료되었습니다.')
     } catch {
       setVerificationStatus('danger')

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -14,6 +14,12 @@ import type { FindIdHandlers } from '@/hooks/useFindId'
 import type { FindPasswordHandlers } from '@/hooks/useFindPassword'
 import { useAuthStore } from '@/store/authStore'
 import type { loginSuccessResponse } from '@/types/auth-type/login'
+import { useFindEmail } from '@/api/queries/auth/useFindEmail'
+import {
+  useSendPhoneVerificationCode,
+  useVerifyPhoneVerificationCode,
+} from '@/api/queries/usePhoneVerification'
+import { getErrorMessage } from '@/utils/getErrorMessage'
 
 type SubmitLoginParams = {
   email: string
@@ -23,24 +29,6 @@ type SubmitLoginParams = {
 type Provider = 'kakao' | 'naver'
 
 type OpenModal = 'none' | 'recover' | 'findId' | 'findPassword'
-
-const findIdHandlers: FindIdHandlers = {
-  onSendCode: async () => {
-    throw new Error(
-      '입력한 이름과 휴대폰 번호로 등록된\n이메일이 존재하지 않습니다.'
-    )
-  },
-
-  onVerifyCode: async () => {
-    throw new Error('인증번호 확인에 실패했습니다.')
-  },
-
-  onFindId: async () => {
-    throw new Error(
-      '입력한 이름과 휴대폰 번호로 등록된\n이메일이 존재하지 않습니다.'
-    )
-  },
-}
 
 const findPasswordHandlers: FindPasswordHandlers = {
   onSendCode: async () => {
@@ -58,13 +46,61 @@ const findPasswordHandlers: FindPasswordHandlers = {
 
 const LoginPage = () => {
   const [openModal, setOpenModal] = useState<OpenModal>('none')
-  const navigate = useNavigate()
 
+  const navigate = useNavigate()
   const { mutate: login } = useLogin()
   const { refetch } = useGetMyInfo(false)
 
   const setAccessToken = useAuthStore((state) => state.setAccessToken)
   const setUser = useAuthStore((state) => state.setUser)
+
+  const findEmailMutation = useFindEmail()
+  const sendCodeMutation = useSendPhoneVerificationCode()
+  const verifyCodeMutation = useVerifyPhoneVerificationCode()
+
+  const findIdHandlers: FindIdHandlers = {
+    onSendCode: async ({ phone }) => {
+      try {
+        await sendCodeMutation.mutateAsync({
+          phone_number: phone,
+        })
+      } catch (error) {
+        getErrorMessage(error, '인증번호 전송에 실패했습니다.')
+      }
+    },
+
+    onVerifyCode: async ({ phone, code }) => {
+      try {
+        await verifyCodeMutation.mutateAsync({
+          code,
+          phone_number: phone,
+        })
+      } catch (error) {
+        throw new Error(getErrorMessage(error, '인증번호 확인에 실패했습니다.'))
+      }
+    },
+
+    onFindId: async ({ name, phone, code }) => {
+      try {
+        const result = await findEmailMutation.mutateAsync({
+          name: name,
+          phone_number: phone,
+          code: code,
+        })
+
+        return {
+          maskedEmail: result.email,
+        }
+      } catch (error) {
+        throw new Error(
+          getErrorMessage(
+            error,
+            '입력하신 정보와 일치하는 계정을 찾을 수 없습니다.'
+          )
+        )
+      }
+    },
+  }
 
   const handleSocialLoginBtnClick = ({ provider }: { provider: Provider }) => {
     void provider
@@ -106,11 +142,11 @@ const LoginPage = () => {
 
   return (
     <div className="bg-ui-gray-100 min-h-screen">
-      <div className="flex justify-center pt-[200px]">
-        <div className="flex w-[348px] flex-col gap-[64px]">
-          <div className="flex flex-col items-center gap-[27px]">
+      <div className="flex justify-center pt-50">
+        <div className="flex w-87 flex-col gap-16">
+          <div className="flex flex-col items-center gap-6.75">
             <img src={logoImg} alt="오즈코딩스쿨" width={180} height={24} />
-            <div className="flex items-center gap-[12px] text-[16px] leading-[140%] tracking-[-0.03em]">
+            <div className="flex items-center gap-3 text-[16px] leading-[140%] tracking-[-0.03em]">
               <span className="text-ui-gray-600">아직 회원이 아니신가요?</span>
               <Link
                 to={ROUTES_PATHS.SIGNUP_PAGE}
@@ -121,8 +157,8 @@ const LoginPage = () => {
             </div>
           </div>
 
-          <div className="flex flex-col gap-[36px]">
-            <div className="flex flex-col gap-[12px]">
+          <div className="flex flex-col gap-9">
+            <div className="flex flex-col gap-3">
               <SocialLoginButton
                 provider="kakao"
                 onClick={() => handleSocialLoginBtnClick({ provider: 'kakao' })}

--- a/src/types/auth-type/findEmail.ts
+++ b/src/types/auth-type/findEmail.ts
@@ -1,0 +1,9 @@
+export type FindEmailRequest = {
+  name: string
+  phone_number: string
+  code: string
+}
+
+export type FindEmailResponse = {
+  email: string
+}

--- a/src/types/mypage-type/verifyPhone.ts
+++ b/src/types/mypage-type/verifyPhone.ts
@@ -13,13 +13,11 @@ export type VerifyPhoneVerificationCodeRequest = {
 
 export type VerifyPhoneVerificationCodeResponse = {
   detail: string
-  token: string
+  sms_token: string
 }
 
 export type ChangePhoneRequest = {
-  phone_verify_token: {
-    token: string
-  }
+  phone_verify_token: string
 }
 
 export type ChangePhoneResponse = {

--- a/src/utils/getErrorMessage.ts
+++ b/src/utils/getErrorMessage.ts
@@ -1,0 +1,35 @@
+import type { ErrorDetailResponse } from '@/types/api-response/myPageResponse'
+import { AxiosError } from 'axios'
+
+export const getErrorMessage = (
+  error: unknown,
+  fallbackMessage: string
+): string => {
+  if (error instanceof AxiosError) {
+    const responseData = error.response?.data as ErrorDetailResponse | undefined
+
+    if (!responseData) {
+      return fallbackMessage
+    }
+
+    if (
+      'error_detail' in responseData &&
+      typeof responseData.error_detail === 'string'
+    ) {
+      return responseData.error_detail
+    }
+
+    if (
+      'error_detail' in responseData &&
+      responseData.error_detail &&
+      typeof responseData.error_detail === 'object'
+    ) {
+      const firstError = Object.values(responseData.error_detail)[0]?.[0]
+      if (firstError) {
+        return firstError
+      }
+    }
+  }
+
+  return fallbackMessage
+}


### PR DESCRIPTION
## 📌 작업 내용

아이디 찾기 API 연동 및 로그인 화면 개선 
- 이메일 찾기 API 함수와 Tanstack Query mutation 훅 추가
- 아이디 찾기 요청/응답 타입 및 엔드포인트 정의
- 로그인 페이지에 인증번호 전송, 인증 확인, 이메일 찾기 플로우 연동
- 아이디 찾기 훅에 휴대폰 번호와 인증번호 기반 검증 로직 반영
- 로그인 폼과 아이디 찾기 모달 UI 간격 및 버튼 스타일 정리

인증 에러 메시지 유틸 추가 및 휴대폰 인증 타입 정리 
- Axios 에러 응답용 공통 메시지 추출 유틸 추가
- 휴대폰 인증 응답값을 `sms_token` 기준으로 맞추고 번호 변경 요청 타입 수정
- 내 정보 수정 화면에 변경된 휴대폰 인증 payload 구조 반영
- 유저 메뉴 프로필 이미지, 회원 탈퇴 모달, 수강 과정 카드 UI 보정

## 🔗 관련 이슈

- closes #114 

## ✅ 체크리스트

- [ ] 코드 컨벤션 확인
- [ ] lint 에러 없음
- [ ] 빌드 정상 확인
