### PR TITLE
refactor: auth persist 제거 및 토큰 저장 구조 변경

### DIFF
--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -1,4 +1,4 @@
-import { API_BASE_URL } from '@/constants/apisPaths'
+import { API_BASE_URL, APIS_PATHS } from '@/constants/apisPaths'
 import axios from 'axios'
 import { useAuthStore } from '@/store/authStore'
 
@@ -32,12 +32,12 @@ api.interceptors.response.use(
     if (
       error.response?.status === 401 &&
       !originalRequest._retry &&
-      !originalRequest.url?.includes('/refresh')
+      !originalRequest.url?.includes(APIS_PATHS.REFRESH_TOKEN)
     ) {
       originalRequest._retry = true
 
       try {
-        const { data } = await api.post('/api/v1/accounts/me/refresh')
+        const { data } = await api.post(APIS_PATHS.REFRESH_TOKEN)
 
         const newToken = data.access_token
 

--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -1,12 +1,6 @@
 import { API_BASE_URL } from '@/constants/apisPaths'
 import axios from 'axios'
-
 import { useAuthStore } from '@/store/authStore'
-
-/**
- * axios - create
- * TODO: baseURL 수정 예정
- */
 
 export const API_BASE = '/api/v1'
 
@@ -15,15 +9,50 @@ export const api = axios.create({
   withCredentials: true,
 })
 
-//요청
 api.interceptors.request.use((config) => {
   const token = useAuthStore.getState().accessToken
 
   if (token) {
+    config.headers = config.headers || {}
     config.headers.Authorization = `Bearer ${token}`
   }
 
   return config
 })
 
-//응답, 오류처리
+api.interceptors.response.use(
+  (response) => response,
+  async (error) => {
+    const originalRequest = error.config
+
+    if (!originalRequest) {
+      return Promise.reject(error)
+    }
+
+    if (
+      error.response?.status === 401 &&
+      !originalRequest._retry &&
+      !originalRequest.url?.includes('/refresh')
+    ) {
+      originalRequest._retry = true
+
+      try {
+        const { data } = await api.post('/api/v1/accounts/me/refresh')
+
+        const newToken = data.access_token
+
+        useAuthStore.getState().setAccessToken(newToken)
+
+        originalRequest.headers = originalRequest.headers || {}
+        originalRequest.headers.Authorization = `Bearer ${newToken}`
+
+        return api(originalRequest)
+      } catch (refreshError) {
+        useAuthStore.getState().logout()
+        return Promise.reject(refreshError)
+      }
+    }
+
+    return Promise.reject(error)
+  }
+)

--- a/src/constants/apisPaths.ts
+++ b/src/constants/apisPaths.ts
@@ -18,12 +18,12 @@ export const APIS_PATHS = {
   PROFILE_IMAGE: '/accounts/me/profile-image',
   CHECK_NICKNAME: '/accounts/check-nickname',
   LOGOUT: '/accounts/logout',
+  REFRESH_TOKEN: '/accounts/me/refresh',
 
   GET_EXAM_DEPLOYMENTS: '/exams/deployments',
   GET_EXAM_RESULT: '/exams/submissions',
 }
 
-//exam 동적 경로처리
 export const EXAM_API_PATHS = {
   DEPLOYMENTS: '/exams/deployments',
   deploymentDetail: (deploymentId: number) =>

--- a/src/store/authStore.ts
+++ b/src/store/authStore.ts
@@ -1,5 +1,4 @@
 import { create } from 'zustand'
-import { persist } from 'zustand/middleware'
 
 type User = {
   id: number
@@ -15,30 +14,11 @@ type AuthState = {
   logout: () => void
 }
 
-export const useAuthStore = create<AuthState>()(
-  persist(
-    (set) => ({
-      accessToken: null,
-      user: null,
+export const useAuthStore = create<AuthState>()((set) => ({
+  accessToken: null,
+  user: null,
 
-      setAccessToken: (token) =>
-        set({
-          accessToken: token,
-        }),
-
-      setUser: (user) =>
-        set({
-          user,
-        }),
-
-      logout: () =>
-        set({
-          accessToken: null,
-          user: null,
-        }),
-    }),
-    {
-      name: 'auth-storage',
-    }
-  )
-)
+  setAccessToken: (token) => set({ accessToken: token }),
+  setUser: (user) => set({ user }),
+  logout: () => set({ accessToken: null, user: null }),
+}))


### PR DESCRIPTION
인증 정보의 브라우저 저장소 노출 보안 이슈 개선

## 📌 작업 내용

- zustand persist 제거
- accessToken 및 user 상태를 메모리 기반으로 관리하도록 변경
- 브라우저(localStorage/sessionStorage)에 인증 정보가 저장되지 않도록 수정
- axios interceptor를 통해 accessToken 자동 첨부 유지
- 401 발생 시 refresh API를 통한 토큰 재발급 및 요청 재시도 처리
- refresh 실패 시 로그아웃 처리 추가

## 🔗 관련 이슈

- closes #121 

## 📸 스크린샷 (선택)

## ✅ 체크리스트

- [ ] 코드 컨벤션 확인
- [ ] lint 에러 없음
- [ ] 빌드 정상 확인
