### PR TITLE
feat: 쪽지시험 상태 api 연결

### DIFF
--- a/src/features/quiz/QuestionItem.tsx
+++ b/src/features/quiz/QuestionItem.tsx
@@ -12,7 +12,7 @@ type QuestionItemProps = {
 function QuestionItem({ question, value, onChange }: QuestionItemProps) {
   return (
     <>
-      <div className="flex items-center">
+      <div className="flex items-center whitespace-nowrap">
         <h2 className="text-ui-gray-primary text-xl font-bold">
           <span className="absolute">{question.number}.</span>
           <span className="ml-8">{question.question}</span>

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -5,9 +5,10 @@ import { checkNickNameHandlers } from './handlers/checkNickNameHandlers'
 import { examHandlers } from './handlers/examHandlers'
 import { mypageHandlers } from './handlers/myPageHandlers'
 import { profileImageHandlers } from './handlers/profileImageHandlers'
+const USE_EXAM_MOCK = false
 
 export const handlers = [
-  ...examHandlers,
+  ...(USE_EXAM_MOCK ? examHandlers : []),
   ...mypageHandlers,
   ...availableCoursesHandlers,
   ...changePasswordHandlers,

--- a/src/mocks/handlers/examHandlers.ts
+++ b/src/mocks/handlers/examHandlers.ts
@@ -1,51 +1,54 @@
 import { API_BASE_URL } from '@/constants/apisPaths'
 import type { ExamStatusResponse } from '@/types/quizpage-type/status'
 import { http, HttpResponse } from 'msw'
+import { mockQuizData } from '../data/examData'
+import { mockExamDeploymentList } from '../data/mockExamDeploymentList'
+import { mockQuizResultData } from '../data/mockQuizResultData'
 
 export const examHandlers = [
-  // // 시험 목록 조회
-  // http.get(`${API_BASE_URL}/exams/deployments`, () => {
-  //   return HttpResponse.json(mockExamDeploymentList, { status: 200 })
-  // }),
+  // 시험 목록 조회
+  http.get(`${API_BASE_URL}/exams/deployments`, () => {
+    return HttpResponse.json(mockExamDeploymentList, { status: 200 })
+  }),
 
-  // // 시험 문제 조회
-  // http.get(`${API_BASE_URL}/exams/deployments/:deploymentId`, ({ params }) => {
-  //   const { deploymentId } = params
+  // 시험 문제 조회
+  http.get(`${API_BASE_URL}/exams/deployments/:deploymentId`, ({ params }) => {
+    const { deploymentId } = params
 
-  //   return HttpResponse.json(
-  //     {
-  //       ...mockQuizData,
-  //       deployment_id: Number(deploymentId),
-  //     },
-  //     { status: 200 }
-  //   )
-  // }),
+    return HttpResponse.json(
+      {
+        ...mockQuizData,
+        deployment_id: Number(deploymentId),
+      },
+      { status: 200 }
+    )
+  }),
 
   // 참가 코드 검증
-  // http.post(
-  //   `${API_BASE_URL}/exams/deployments/:deploymentId/check-code`,
-  //   async ({ request, params }) => {
-  //     const body = (await request.json()) as { code?: string }
-  //     const { deploymentId } = params
+  http.post(
+    `${API_BASE_URL}/exams/deployments/:deploymentId/check-code`,
+    async ({ request, params }) => {
+      const body = (await request.json()) as { code?: string }
+      const { deploymentId } = params
 
-  //     if (body.code === '1234') {
-  //       return HttpResponse.json(
-  //         {
-  //           message: '참가 코드가 확인되었습니다.',
-  //           deployment_id: Number(deploymentId),
-  //         },
-  //         { status: 200 }
-  //       )
-  //     }
+      if (body.code === '1234') {
+        return HttpResponse.json(
+          {
+            message: '참가 코드가 확인되었습니다.',
+            deployment_id: Number(deploymentId),
+          },
+          { status: 200 }
+        )
+      }
 
-  //     return HttpResponse.json(
-  //       {
-  //         message: '참가 코드가 올바르지 않습니다.',
-  //       },
-  //       { status: 400 }
-  //     )
-  //   }
-  // ),
+      return HttpResponse.json(
+        {
+          message: '참가 코드가 올바르지 않습니다.',
+        },
+        { status: 400 }
+      )
+    }
+  ),
 
   // 응시 상태 확인
   http.get(
@@ -83,16 +86,16 @@ export const examHandlers = [
     }
   ),
 
-  // // 시험 결과 조회
-  // http.get(`${API_BASE_URL}/exams/submissions/:submissionId`, ({ params }) => {
-  //   const { submissionId } = params
+  // 시험 결과 조회
+  http.get(`${API_BASE_URL}/exams/submissions/:submissionId`, ({ params }) => {
+    const { submissionId } = params
 
-  //   return HttpResponse.json(
-  //     {
-  //       ...mockQuizResultData,
-  //       submission_id: Number(submissionId),
-  //     },
-  //     { status: 200 }
-  //   )
-  // }),
+    return HttpResponse.json(
+      {
+        ...mockQuizResultData,
+        submission_id: Number(submissionId),
+      },
+      { status: 200 }
+    )
+  }),
 ]

--- a/src/pages/QuizPage.tsx
+++ b/src/pages/QuizPage.tsx
@@ -17,30 +17,30 @@ import { useCheatingDetection } from '@/hooks/exam/useCheatingDetection'
 import { useQuizTimer } from '@/hooks/exam/useQuizTimer'
 import type { AnswerMap, AnswerValue } from '@/types/answer-type/answer'
 import { createSubmitPayload } from '@/utils/createSubmitPayload'
-
 function QuizPage() {
   const navigate = useNavigate()
   const { deploymentId } = useParams()
   const numericDeploymentId = Number(deploymentId)
+
   const [startedAt] = useState(() => new Date().toISOString())
   const [answers, setAnswers] = useState<AnswerMap>({})
   const [isWarningVisible, setIsWarningVisible] = useState(true)
   const [isSubmitting, setIsSubmitting] = useState(false)
-  const [isError, setIsError] = useState(false)
   const [isSubmitModalOpen, setIsSubmitModalOpen] = useState(false)
-  const [isTerminated, setIsTerminated] = useState(false)
+
+  // 부정행위로 종료된 경우만 state로 관리
+  const [isCheatingTerminated, setIsCheatingTerminated] = useState(false)
+
+  const isStatusEnabled = !Number.isNaN(numericDeploymentId)
 
   const {
     data: statusData,
     isLoading: isStatusLoading,
     isError: isStatusError,
-  } = useStatus(numericDeploymentId, !!numericDeploymentId)
+  } = useStatus(numericDeploymentId, isStatusEnabled)
 
   const shouldFetchQuestions =
-    !!numericDeploymentId &&
-    !Number.isNaN(numericDeploymentId) &&
-    !!statusData &&
-    !(statusData.exam_status === 'closed' && statusData.force_submit)
+    isStatusEnabled && statusData?.exam_status === 'activated'
 
   const {
     data: quizData,
@@ -49,6 +49,7 @@ function QuizPage() {
   } = useExamQuestions(numericDeploymentId, shouldFetchQuestions)
 
   const submitExamMutation = useSubmitExam()
+
   const {
     cheatingCount,
     isCheatingModalOpen,
@@ -58,9 +59,12 @@ function QuizPage() {
   } = useCheatingDetection({
     isSubmitting,
     onTerminate: async () => {
-      setIsTerminated(true)
+      setIsCheatingTerminated(true)
     },
   })
+
+  const isServerTerminated = statusData?.exam_status === 'closed'
+  const isTerminated = isServerTerminated || isCheatingTerminated
 
   const isAnswered = useCallback((answer: AnswerValue) => {
     if (answer === null) {
@@ -90,6 +94,7 @@ function QuizPage() {
     if (!quizData) {
       return false
     }
+
     return quizData.questions.every((question) =>
       isAnswered(answers[question.question_id] ?? null)
     )
@@ -100,14 +105,18 @@ function QuizPage() {
       if (isSubmitting) {
         return
       }
+
       if (!quizData) {
         return
       }
+
       if (!force && !isAllQuestionsAnswered) {
         toast.error('모든 문제를 풀어야 제출할 수 있습니다.')
         return
       }
+
       setIsSubmitting(true)
+
       try {
         const payload = createSubmitPayload({
           deploymentId: numericDeploymentId,
@@ -159,24 +168,24 @@ function QuizPage() {
   )
 
   const handleBack = useCallback(() => {
-    if (isTerminated) {
-      return
-    }
     navigate(getMyPageTab('exam'))
-  }, [isTerminated, navigate])
+  }, [navigate])
 
   useEffect(() => {
     const enterFullscreen = async () => {
       if (document.fullscreenElement) {
         return
       }
+
       try {
         await document.documentElement.requestFullscreen()
       } catch (error) {
         console.warn('전체화면 진입이 차단되었습니다.')
       }
     }
+
     enterFullscreen()
+
     return () => {
       if (document.fullscreenElement) {
         document.exitFullscreen().catch(() => {})
@@ -184,35 +193,28 @@ function QuizPage() {
     }
   }, [])
 
-  useEffect(() => {
-    if (Number.isNaN(numericDeploymentId)) {
-      setIsError(true)
-    }
-  }, [numericDeploymentId])
-
-  useEffect(() => {
-    if (!statusData) {
-      return
-    }
-    if (statusData.exam_status === 'closed' && statusData.force_submit) {
-      setIsTerminated(true)
-    }
-  }, [statusData])
-
-  if (isError || isStatusError || isQuizError) {
+  if (isStatusError || isQuizError) {
     return <div>시험 정보를 불러오지 못했습니다.</div>
   }
 
   if (isTerminated) {
     return (
       <ExamTerminatedModal
-        isOpen={isTerminated}
+        isOpen
         onConfirm={() => navigate(getMyPageTab('exam'))}
       />
     )
   }
 
-  if (isStatusLoading || isQuizLoading || !quizData) {
+  if (isStatusLoading) {
+    return <div>로딩중...</div>
+  }
+
+  if (statusData?.exam_status === 'pending') {
+    return <div>시험 대기중입니다.</div>
+  }
+
+  if (isQuizLoading || !quizData) {
     return <div>로딩중...</div>
   }
 

--- a/src/types/quizpage-type/status.ts
+++ b/src/types/quizpage-type/status.ts
@@ -1,4 +1,4 @@
-export type ExamStatus = 'activated' | 'closed'
+export type ExamStatus = 'pending' | 'activated' | 'closed'
 
 export type ExamStatusResponse = {
   exam_status: ExamStatus


### PR DESCRIPTION
## 📌 작업 내용

- 쪽지시험 상태 조회 API 연결
- 시험 상태(`pending`, `activated`, `closed`)에 따른 화면 분기 처리
- `activated` 상태에서만 문제 조회 API가 호출되도록 수정

## 🔗 관련 이슈

- closes #127 

## 📸 스크린샷 (선택)

## ✅ 체크리스트
<img width="310" height="94" alt="image" src="https://github.com/user-attachments/assets/8196d8c4-0429-495d-894b-d0c4cfffed97" />


- [ ] 코드 컨벤션 확인
- [ ] lint 에러 없음
- [ ] 빌드 정상 확인
