### PR TITLE
feat: 시험제출 api 연결 (#131)

### DIFF
--- a/src/api/exam.ts
+++ b/src/api/exam.ts
@@ -41,16 +41,14 @@ export const getExamStatus = async (
 }
 
 export const submitExam = async (
-  deploymentId: number,
   payload: SubmitExamRequest
 ): Promise<SubmitExamResponse> => {
   const { data } = await api.post<SubmitExamResponse>(
-    EXAM_API_PATHS.submit(deploymentId),
+    EXAM_API_PATHS.submit,
     payload
   )
   return data
 }
-
 export const getExamResult = async (
   submissionId: number
 ): Promise<ResultData> => {

--- a/src/api/queries/exam/useSubmitExam.ts
+++ b/src/api/queries/exam/useSubmitExam.ts
@@ -9,7 +9,6 @@ type SubmitExamParams = {
 
 export const useSubmitExam = () => {
   return useMutation({
-    mutationFn: ({ deploymentId, payload }: SubmitExamParams) =>
-      submitExam(deploymentId, payload),
+    mutationFn: ({ payload }: SubmitExamParams) => submitExam(payload),
   })
 }

--- a/src/constants/apisPaths.ts
+++ b/src/constants/apisPaths.ts
@@ -28,7 +28,6 @@ export const APIS_PATHS = {
   GET_EXAM_DEPLOYMENTS: '/exams/deployments',
   GET_EXAM_RESULT: '/exams/submissions',
 }
-
 export const EXAM_API_PATHS = {
   DEPLOYMENTS: '/exams/deployments',
   deploymentDetail: (deploymentId: number) =>
@@ -36,6 +35,6 @@ export const EXAM_API_PATHS = {
   checkCode: (deploymentId: number) =>
     `/exams/deployments/${deploymentId}/check-code`,
   status: (deploymentId: number) => `/exams/deployments/${deploymentId}/status`,
-  submit: (deploymentId: number) => `/exams/deployments/${deploymentId}/submit`,
+  submit: '/exams/submissions',
   result: (submissionId: number) => `/exams/submissions/${submissionId}`,
 }

--- a/src/features/quiz-result/ShortAnswerResult.tsx
+++ b/src/features/quiz-result/ShortAnswerResult.tsx
@@ -6,9 +6,12 @@ type ShortAnswerResultProps = {
 }
 
 function ShortAnswerResult({ question }: ShortAnswerResultProps) {
-  const answer =
-    question.submitted_answer && question.submitted_answer.length > 0
+  const answer = Array.isArray(question.submitted_answer)
+    ? question.submitted_answer.length > 0
       ? question.submitted_answer.join(', ')
+      : '미응답'
+    : question.submitted_answer && question.submitted_answer.trim() !== ''
+      ? question.submitted_answer
       : '미응답'
 
   return (

--- a/src/pages/QuizPage.tsx
+++ b/src/pages/QuizPage.tsx
@@ -17,10 +17,12 @@ import { useCheatingDetection } from '@/hooks/exam/useCheatingDetection'
 import { useQuizTimer } from '@/hooks/exam/useQuizTimer'
 import type { AnswerMap, AnswerValue } from '@/types/answer-type/answer'
 import { createSubmitPayload } from '@/utils/createSubmitPayload'
+
 function QuizPage() {
   const navigate = useNavigate()
   const { deploymentId } = useParams()
   const numericDeploymentId = Number(deploymentId)
+  const submitExamMutation = useSubmitExam()
 
   const [startedAt] = useState(() => new Date().toISOString())
   const [answers, setAnswers] = useState<AnswerMap>({})
@@ -47,8 +49,6 @@ function QuizPage() {
     isLoading: isQuizLoading,
     isError: isQuizError,
   } = useExamQuestions(numericDeploymentId, shouldFetchQuestions)
-
-  const submitExamMutation = useSubmitExam()
 
   const {
     cheatingCount,
@@ -102,15 +102,25 @@ function QuizPage() {
 
   const handleSubmit = useCallback(
     async (force = false) => {
+      console.log('submit click', {
+        isSubmitting,
+        quizData,
+        isAllQuestionsAnswered,
+        force,
+      })
+
       if (isSubmitting) {
+        console.log('return: isSubmitting')
         return
       }
 
       if (!quizData) {
+        console.log('return: no quizData')
         return
       }
 
       if (!force && !isAllQuestionsAnswered) {
+        console.log('return: not all answered')
         toast.error('모든 문제를 풀어야 제출할 수 있습니다.')
         return
       }
@@ -125,13 +135,20 @@ function QuizPage() {
           quizData,
           answers,
         })
+
+        console.log('submit payload', payload)
+
         const result = await submitExamMutation.mutateAsync({
           deploymentId: numericDeploymentId,
           payload,
         })
+
+        console.log('submit result', result)
+
         navigate(getQuizResultPage(result.submission_id))
         setIsSubmitModalOpen(false)
       } catch (error) {
+        console.log('submit error', error)
         toast.error('시험 제출에 실패했습니다.')
       } finally {
         setIsSubmitting(false)

--- a/src/pages/QuizPage.tsx
+++ b/src/pages/QuizPage.tsx
@@ -102,25 +102,15 @@ function QuizPage() {
 
   const handleSubmit = useCallback(
     async (force = false) => {
-      console.log('submit click', {
-        isSubmitting,
-        quizData,
-        isAllQuestionsAnswered,
-        force,
-      })
-
       if (isSubmitting) {
-        console.log('return: isSubmitting')
         return
       }
 
       if (!quizData) {
-        console.log('return: no quizData')
         return
       }
 
       if (!force && !isAllQuestionsAnswered) {
-        console.log('return: not all answered')
         toast.error('모든 문제를 풀어야 제출할 수 있습니다.')
         return
       }
@@ -135,20 +125,13 @@ function QuizPage() {
           quizData,
           answers,
         })
-
-        console.log('submit payload', payload)
-
         const result = await submitExamMutation.mutateAsync({
           deploymentId: numericDeploymentId,
           payload,
         })
-
-        console.log('submit result', result)
-
         navigate(getQuizResultPage(result.submission_id))
         setIsSubmitModalOpen(false)
       } catch (error) {
-        console.log('submit error', error)
         toast.error('시험 제출에 실패했습니다.')
       } finally {
         setIsSubmitting(false)

--- a/src/types/result-type/answer.ts
+++ b/src/types/result-type/answer.ts
@@ -1,6 +1,6 @@
 import type { QuizQuestionType } from '../quizpage-type/question'
 
-export type ResultAnswer = string[] | null
+export type ResultAnswer = string | string[] | null
 
 export type ResultQuestion = {
   id: number


### PR DESCRIPTION
## 📌 작업 내용

- 쪽지시험 제출 API 연결 (POST /exams/submissions)
- 제출 payload 생성 로직 구현 (createSubmitPayload)
- 제출 성공 시 결과 페이지로 이동 처리

- api 테스트 완료

## 🔗 관련 이슈

- closes #131 

## 📸 스크린샷 (선택)
<img width="768" height="137" alt="image" src="https://github.com/user-attachments/assets/646dd538-91e4-48bd-ad9b-6f61287bd9c2" />
<img width="1920" height="2889" alt="screencapture-localhost-5173-result-11-2026-03-29-16_22_03" src="https://github.com/user-attachments/assets/7774f458-64ad-4ba0-b64b-31c67a9d07fc" />

## ✅ 체크리스트

- [ ] 코드 컨벤션 확인
- [ ] lint 에러 없음
- [ ] 빌드 정상 확인
