### PR TITLE
fix: 로그인 새로고침 수정

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,7 @@ import './App.css'
 import QuizLayout from './components/layout/QuizLayout'
 import Rootlayout from './components/layout/RootLayout'
 import { ROUTES_PATHS } from './constants/routesPaths'
+import { useAuthBootstrap } from './features/auth/useAuthBootstrap'
 import HomePage from './pages/HomePage'
 import LoginPage from './pages/LoginPage'
 import MyPage from './pages/MyPage'
@@ -14,6 +15,8 @@ import SignupPage from './pages/SignupPage'
 import TestPage from './pages/TestPage'
 
 function App() {
+  useAuthBootstrap()
+
   return (
     <Routes>
       <Route element={<Rootlayout />}>

--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -17,6 +17,10 @@ import type {
   RestoreAccountResponse,
 } from '@/types/auth-type/restoreAccount'
 
+type RefreshResponse = {
+  access_token: string
+}
+
 export const postLogin = async (
   payload: loginRequest
 ): Promise<loginSuccessResponse> => {
@@ -28,7 +32,9 @@ export const postLogin = async (
   return data
 }
 
-export const postFindEmail = async (payload: FindEmailRequest) => {
+export const postFindEmail = async (
+  payload: FindEmailRequest
+): Promise<FindEmailResponse> => {
   const { data } = await api.post<FindEmailResponse>(
     APIS_PATHS.FIND_EMAIL,
     payload
@@ -52,5 +58,10 @@ export const postRestoreAccount = async (payload: RestoreAccountRequest) => {
     payload
   )
 
+  return data
+}
+
+export const postRefreshToken = async (): Promise<RefreshResponse> => {
+  const { data } = await api.post<RefreshResponse>(APIS_PATHS.REFRESH_TOKEN)
   return data
 }

--- a/src/api/interceptors.ts
+++ b/src/api/interceptors.ts
@@ -1,0 +1,89 @@
+import { api } from './api'
+import type { AxiosError, InternalAxiosRequestConfig } from 'axios'
+import { useAuthStore } from '@/store/authStore'
+import { postRefreshToken } from '@/api/auth'
+
+type RetryConfig = InternalAxiosRequestConfig & {
+  _retry?: boolean
+}
+
+let isRefreshing = false
+let subscribers: ((token: string) => void)[] = []
+
+const subscribe = (callback: (token: string) => void) => {
+  subscribers.push(callback)
+}
+
+const notifySubscribers = (token: string) => {
+  subscribers.forEach((cb) => cb(token))
+  subscribers = []
+}
+
+export const setupInterceptors = () => {
+  // ✅ 요청 시 토큰 자동 추가
+  api.interceptors.request.use(
+    (config) => {
+      const token = useAuthStore.getState().accessToken
+
+      if (token) {
+        config.headers.Authorization = `Bearer ${token}`
+      }
+
+      return config
+    },
+    (error) => Promise.reject(error)
+  )
+
+  // ✅ 응답 처리 (401 → refresh → 재요청)
+  api.interceptors.response.use(
+    (res) => res,
+    async (error: AxiosError) => {
+      const originalRequest = error.config as RetryConfig
+
+      if (!originalRequest) return Promise.reject(error)
+
+      const status = error.response?.status
+
+      // 401 아니면 그냥 에러
+      if (status !== 401) {
+        return Promise.reject(error)
+      }
+
+      // 이미 재시도 했으면 종료 (무한루프 방지)
+      if (originalRequest._retry) {
+        useAuthStore.getState().logout()
+        return Promise.reject(error)
+      }
+
+      originalRequest._retry = true
+
+      // 이미 refresh 중이면 기다렸다가 재요청
+      if (isRefreshing) {
+        return new Promise((resolve) => {
+          subscribe((token: string) => {
+            originalRequest.headers.Authorization = `Bearer ${token}`
+            resolve(api(originalRequest))
+          })
+        })
+      }
+
+      isRefreshing = true
+
+      try {
+        const { access_token } = await postRefreshToken()
+
+        useAuthStore.getState().setAccessToken(access_token)
+
+        notifySubscribers(access_token)
+
+        originalRequest.headers.Authorization = `Bearer ${access_token}`
+        return api(originalRequest)
+      } catch (err) {
+        useAuthStore.getState().logout()
+        return Promise.reject(err)
+      } finally {
+        isRefreshing = false
+      }
+    }
+  )
+}

--- a/src/api/queries/myInfo/useGetMyInfo.ts
+++ b/src/api/queries/myInfo/useGetMyInfo.ts
@@ -1,12 +1,16 @@
 import { getMyInfo } from '@/api/mypage'
 import { useQuery } from '@tanstack/react-query'
+import { useAuthStore } from '@/store/authStore'
 
 export const MY_INFO_QUERY_KEY = ['my-info']
 
 export const useGetMyInfo = (enabled = true) => {
+  const accessToken = useAuthStore((state) => state.accessToken)
+  const isAuthInitialized = useAuthStore((state) => state.isAuthInitialized)
+
   return useQuery({
     queryKey: MY_INFO_QUERY_KEY,
     queryFn: getMyInfo,
-    enabled: enabled,
+    enabled: enabled && isAuthInitialized && !!accessToken,
   })
 }

--- a/src/features/auth/useAuthBootstrap.ts
+++ b/src/features/auth/useAuthBootstrap.ts
@@ -1,0 +1,34 @@
+import { useEffect, useRef } from 'react'
+import { postRefreshToken } from '@/api/auth'
+import { getMyInfo } from '@/api/mypage'
+import { useAuthStore } from '@/store/authStore'
+
+export const useAuthBootstrap = () => {
+  const hasRun = useRef(false)
+
+  const setAccessToken = useAuthStore((state) => state.setAccessToken)
+  const setUser = useAuthStore((state) => state.setUser)
+  const setAuthInitialized = useAuthStore((state) => state.setAuthInitialized)
+
+  useEffect(() => {
+    if (hasRun.current) return
+    hasRun.current = true
+
+    const initAuth = async () => {
+      try {
+        const { access_token } = await postRefreshToken()
+        setAccessToken(access_token)
+
+        const user = await getMyInfo()
+        setUser(user)
+      } catch {
+        setAccessToken(null)
+        setUser(null)
+      } finally {
+        setAuthInitialized(true)
+      }
+    }
+
+    void initAuth()
+  }, [setAccessToken, setUser, setAuthInitialized])
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -4,22 +4,23 @@ import { createRoot } from 'react-dom/client'
 import { BrowserRouter } from 'react-router-dom'
 import App from './App.tsx'
 import './index.css'
-
+import { setupInterceptors } from '@/api/interceptors'
 const queryClient = new QueryClient()
 
 async function enableMocking() {
   if (!import.meta.env.DEV) {
-    // node -> vite는 DEV
     return
   }
-  const { worker } = await import('./mocks/browser.ts') // 이전에 설정한 브라우저 환경설정 import
+  const { worker } = await import('./mocks/browser.ts')
 
   return worker.start({
-    onUnhandledRequest: 'bypass', // 모킹되지 않은 요청은 실제 서버로 전달
+    onUnhandledRequest: 'bypass',
   })
 }
 
 enableMocking().then(() => {
+  setupInterceptors()
+
   createRoot(document.getElementById('root')!).render(
     <StrictMode>
       <QueryClientProvider client={queryClient}>

--- a/src/store/authStore.ts
+++ b/src/store/authStore.ts
@@ -1,5 +1,4 @@
 import { create } from 'zustand'
-import { persist, createJSONStorage } from 'zustand/middleware'
 
 type User = {
   id: number
@@ -9,25 +8,27 @@ type User = {
 type AuthState = {
   accessToken: string | null
   user: User | null
+  isAuthInitialized: boolean
 
   setAccessToken: (token: string | null) => void
   setUser: (user: User | null) => void
+  setAuthInitialized: (value: boolean) => void
   logout: () => void
 }
 
-export const useAuthStore = create<AuthState>()(
-  persist(
-    (set) => ({
+export const useAuthStore = create<AuthState>((set) => ({
+  accessToken: null,
+  user: null,
+  isAuthInitialized: false,
+
+  setAccessToken: (token) => set({ accessToken: token }),
+  setUser: (user) => set({ user }),
+  setAuthInitialized: (value) => set({ isAuthInitialized: value }),
+
+  logout: () =>
+    set({
       accessToken: null,
       user: null,
-
-      setAccessToken: (token) => set({ accessToken: token }),
-      setUser: (user) => set({ user }),
-      logout: () => set({ accessToken: null, user: null }),
+      isAuthInitialized: true,
     }),
-    {
-      name: 'auth-storage',
-      storage: createJSONStorage(() => sessionStorage),
-    }
-  )
-)
+}))

--- a/src/store/authStore.ts
+++ b/src/store/authStore.ts
@@ -1,4 +1,5 @@
 import { create } from 'zustand'
+import { persist, createJSONStorage } from 'zustand/middleware'
 
 type User = {
   id: number
@@ -14,11 +15,19 @@ type AuthState = {
   logout: () => void
 }
 
-export const useAuthStore = create<AuthState>()((set) => ({
-  accessToken: null,
-  user: null,
+export const useAuthStore = create<AuthState>()(
+  persist(
+    (set) => ({
+      accessToken: null,
+      user: null,
 
-  setAccessToken: (token) => set({ accessToken: token }),
-  setUser: (user) => set({ user }),
-  logout: () => set({ accessToken: null, user: null }),
-}))
+      setAccessToken: (token) => set({ accessToken: token }),
+      setUser: (user) => set({ user }),
+      logout: () => set({ accessToken: null, user: null }),
+    }),
+    {
+      name: 'auth-storage',
+      storage: createJSONStorage(() => sessionStorage),
+    }
+  )
+)


### PR DESCRIPTION
## 📌 작업 내용

- 로그인 후 새로고침 시 인증 상태가 초기화되어 로그아웃되는 문제 해결
- zustand authStore에 persist 적용
- sessionStorage에 로그인 상태(accessToken, user) 저장
- 새로고침 시 로그인 상태 유지 확인
- 로그아웃 시 accessToken, user 값이 null로 초기화되는 것 확인

**참고 사항**
- auth-storage key는 sessionStorage에 유지되지만, 내부 값이 { accessToken: null, user: null }인 경우 정상 로그아웃 상태로 판단했습니다.
- 이번 이슈는 로그인 상태 유지에 초점을 두었으며, axios 인터셉터 및 사용자 정보 재조회(getMyInfo)는 범위에서 제외했습니다.

## 🔗 관련 이슈

- closes #134 

## 📸 스크린샷 (선택)

## ✅ 체크리스트

- [ ] 코드 컨벤션 확인
- [ ] lint 에러 없음
- [ ] 빌드 정상 확인
