### PR TITLE
feat: 계정 복구 API 추가

### DIFF
--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -1,3 +1,4 @@
+import { api, publicApi } from './api'
 import { APIS_PATHS } from '@/constants/apisPaths'
 import type {
   FindEmailRequest,
@@ -11,12 +12,15 @@ import type {
   ResetPasswordRequest,
   ResetPasswordResponse,
 } from '@/types/auth-type/resetPassword'
-import { api } from './api'
+import type {
+  RestoreAccountRequest,
+  RestoreAccountResponse,
+} from '@/types/auth-type/restoreAccount'
 
 export const postLogin = async (
   payload: loginRequest
 ): Promise<loginSuccessResponse> => {
-  const { data } = await api.post<loginSuccessResponse>(
+  const { data } = await publicApi.post<loginSuccessResponse>(
     APIS_PATHS.POST_LOGIN,
     payload
   )
@@ -38,5 +42,15 @@ export const postResetPassword = async (payload: ResetPasswordRequest) => {
     APIS_PATHS.RESET_PASSWORD,
     payload
   )
+
+  return data
+}
+
+export const postRestoreAccount = async (payload: RestoreAccountRequest) => {
+  const { data } = await publicApi.post<RestoreAccountResponse>(
+    APIS_PATHS.ACCOUNTS_RESTORE,
+    payload
+  )
+
   return data
 }

--- a/src/api/queries/auth/useRestoreAccount.ts
+++ b/src/api/queries/auth/useRestoreAccount.ts
@@ -1,0 +1,9 @@
+import { useMutation } from '@tanstack/react-query'
+
+import { postRestoreAccount } from '@/api/auth'
+
+export const useRestoreAccount = () => {
+  return useMutation({
+    mutationFn: postRestoreAccount,
+  })
+}

--- a/src/api/signup.ts
+++ b/src/api/signup.ts
@@ -40,14 +40,15 @@ export const useVerifyEmailVerificationCode = () => {
     },
   })
 }
-// 비밀번호 인증 전송
+
+//휴대폰 번호 인증 전송
 export const useSendPhoneVerificationCode = () => {
   return useMutation({
     mutationFn: sendPhoneVerificationCode,
   })
 }
 
-// 비밀번호 확인
+//휴대폰 번호 인증 확인
 export const useVerifyPhoneVerificationCode = () => {
   return useMutation({
     mutationFn: verifyPhoneVerificationCode,

--- a/src/constants/apisPaths.ts
+++ b/src/constants/apisPaths.ts
@@ -24,6 +24,7 @@ export const APIS_PATHS = {
   SEND_EMAIL_VERIFICATION: '/accounts/verification/send-email',
   VERIFY_EMAIL_VERIFICATION: '/accounts/verification/verify-email',
 
+  ACCOUNTS_RESTORE: '/accounts/restore',
   FIND_EMAIL: '/accounts/find-email',
   GET_EXAM_DEPLOYMENTS: '/exams/deployments',
   GET_EXAM_RESULT: '/exams/submissions',

--- a/src/features/auth/recover-account/RecoverAccountModal.tsx
+++ b/src/features/auth/recover-account/RecoverAccountModal.tsx
@@ -9,6 +9,7 @@ import Button from '@/components/ui/button'
 import Modal from '@/components/ui/modal/Modal'
 import Popup from '@/components/ui/modal/Popup'
 import { useRecoverAccountVerification } from '@/features/auth/recover-account/useRecoverAccountVerification'
+import { ROUTES_PATHS } from '@/constants/routesPaths'
 
 type RecoverStep = 'inactive' | 'verify'
 
@@ -30,6 +31,7 @@ const RecoverAccountModal = ({ isOpen, onClose }: RecoverAccountModalProps) => {
     isSendToastVisible,
     isCompletePopupVisible,
     formattedTime,
+    isPending,
     handleEmailChange,
     handleCodeChange,
     handleSendCode,
@@ -45,12 +47,14 @@ const RecoverAccountModal = ({ isOpen, onClose }: RecoverAccountModalProps) => {
   }, [isOpen])
 
   useEffect(() => {
-    if (!isCompletePopupVisible) return
+    if (!isCompletePopupVisible) {
+      return
+    }
 
     const timer = window.setTimeout(() => {
       closeCompletePopup()
       onClose()
-      navigate('/login')
+      navigate(ROUTES_PATHS.LOGIN_PAGE)
     }, 2000)
 
     return () => window.clearTimeout(timer)
@@ -62,10 +66,10 @@ const RecoverAccountModal = ({ isOpen, onClose }: RecoverAccountModalProps) => {
 
   const renderInactiveContent = () => {
     return (
-      <div className="flex flex-col gap-[32px] px-[24px] pb-[24px]">
-        <div className="flex flex-col items-center gap-[16px] text-center">
-          <RecoveryIconSvg className="h-[28px] w-[28px]" />
-          <div className="flex flex-col items-center gap-[12px]">
+      <div className="flex flex-col gap-8 px-6 pb-6">
+        <div className="flex flex-col items-center gap-4 text-center">
+          <RecoveryIconSvg className="h-7 w-7" />
+          <div className="flex flex-col items-center gap-3">
             <h2 className="text-ui-gray-primary text-[20px] leading-[140%] font-bold tracking-[-0.03em]">
               해당 계정은 탈퇴된 상태예요
             </h2>
@@ -90,10 +94,10 @@ const RecoverAccountModal = ({ isOpen, onClose }: RecoverAccountModalProps) => {
 
   const renderVerifyContent = () => {
     return (
-      <div className="flex flex-col gap-[40px] px-[24px] pb-[24px]">
-        <div className="flex flex-col items-center gap-[16px] text-center">
-          <RecoveryVerifyIconSvg className="h-[28px] w-[28px]" />
-          <div className="flex flex-col items-center gap-[12px]">
+      <div className="flex flex-col gap-10 px-6 pb-6">
+        <div className="flex flex-col items-center gap-4 text-center">
+          <RecoveryVerifyIconSvg className="h-7 w-7" />
+          <div className="flex flex-col items-center gap-3">
             <h2 className="text-ui-gray-primary text-[20px] leading-[140%] font-bold tracking-[-0.03em]">
               계정 다시 사용하기
             </h2>
@@ -115,16 +119,21 @@ const RecoverAccountModal = ({ isOpen, onClose }: RecoverAccountModalProps) => {
           verificationCode={code}
           onVerificationCodeChange={handleCodeChange}
           verificationCodePlaceholder="인증번호 6자리를 입력해주세요"
-          onSendCode={handleSendCode}
-          onVerifyCode={handleVerifyCode}
+          onSendCode={() => void handleSendCode()}
+          onVerifyCode={() => void handleVerifyCode()}
           isCodeSent={isCodeSent}
           isCodeVerified={isCodeVerified}
           errorMessage={errorMessage}
           formattedTime={formattedTime}
         />
 
-        <Button variant="fill" size="full" onClick={handleCompleteButtonClick}>
-          확인
+        <Button
+          variant="fill"
+          size="full"
+          onClick={() => void handleCompleteButtonClick()}
+          disabled={isPending}
+        >
+          {isPending ? '처리 중...' : '확인'}
         </Button>
       </div>
     )
@@ -133,8 +142,8 @@ const RecoverAccountModal = ({ isOpen, onClose }: RecoverAccountModalProps) => {
   return (
     <>
       {isSendToastVisible && (
-        <div className="border-ui-gray-200 bg-ui-gray-100 fixed top-4 left-1/2 z-[1001] flex h-[48px] w-fit -translate-x-1/2 items-center gap-[12px] rounded-[4px] border px-[16px] py-[12px] whitespace-nowrap shadow-[4px_4px_4px_rgba(131,131,131,0.25)]">
-          <CheckToastIconSvg className="h-[24px] w-[24px] shrink-0" />
+        <div className="border-ui-gray-200 bg-ui-gray-100 fixed top-4 left-1/2 z-1001 flex h-12 w-fit -translate-x-1/2 items-center gap-3 rounded-lg border px-4 py-3 whitespace-nowrap shadow-[4px_4px_4px_rgba(131,131,131,0.25)]">
+          <CheckToastIconSvg className="h-6 w-6 shrink-0" />
           <span className="text-ui-gray-600 text-[14px] leading-[140%] font-normal tracking-[-0.03em]">
             전송 완료! 이메일을 확인해주세요.
           </span>
@@ -156,8 +165,8 @@ const RecoverAccountModal = ({ isOpen, onClose }: RecoverAccountModalProps) => {
         onClose={closeCompletePopup}
         width="w-[396px]"
       >
-        <div className="flex flex-col items-center gap-[10px] p-[24px] text-center">
-          <div className="flex h-[24px] w-[24px] items-center justify-center rounded-full bg-[#14C786]">
+        <div className="flex flex-col items-center gap-2.5 p-6 text-center">
+          <div className="flex h-6 w-6 items-center justify-center rounded-full bg-[#14C786]">
             <svg width="13" height="9" viewBox="0 0 13 9" fill="none">
               <path
                 d="M1.5 4.5L5 8L11.5 1"
@@ -169,7 +178,7 @@ const RecoverAccountModal = ({ isOpen, onClose }: RecoverAccountModalProps) => {
             </svg>
           </div>
 
-          <div className="flex flex-col gap-[12px]">
+          <div className="flex flex-col gap-3">
             <p className="text-ui-gray-primary text-[20px] leading-[140%] font-bold tracking-[-0.03em]">
               계정 복구 완료!
             </p>

--- a/src/features/auth/recover-account/useRecoverAccountVerification.ts
+++ b/src/features/auth/recover-account/useRecoverAccountVerification.ts
@@ -1,11 +1,11 @@
 import { useCallback, useEffect, useState } from 'react'
 
 import { useTimer } from '@/hooks/useTimer'
+import { useRestoreAccount } from '@/api/queries/auth/useRestoreAccount'
+import { getErrorMessage } from '@/utils/getErrorMessage'
+import { useEmailVerificationActions } from '../shared/useEmailVerificationActions'
 
 const INITIAL_TIME = 300
-
-// TODO: API 연동 시 제거
-const MOCK_VERIFY_CODE = '123456'
 
 type UseRecoverAccountVerificationParams = {
   isOpen: boolean
@@ -21,9 +21,16 @@ export const useRecoverAccountVerification = ({
   const [errorMessage, setErrorMessage] = useState('')
   const [isSendToastVisible, setIsSendToastVisible] = useState(false)
   const [isCompletePopupVisible, setIsCompletePopupVisible] = useState(false)
+  const [emailToken, setEmailToken] = useState<string | null>(null)
+
+  const { mutateAsync: restoreAccountMutateAsync, isPending } =
+    useRestoreAccount()
 
   const { formattedTime, isExpired, startTimer, stopTimer, resetTimer } =
     useTimer(INITIAL_TIME)
+
+  const { handleSendEmailCode, handleVerifyEmailCode } =
+    useEmailVerificationActions()
 
   const resetVerificationState = useCallback(() => {
     setEmail('')
@@ -43,7 +50,9 @@ export const useRecoverAccountVerification = ({
   }, [isOpen, resetVerificationState])
 
   useEffect(() => {
-    if (!isSendToastVisible) return
+    if (!isSendToastVisible) {
+      return
+    }
 
     const timer = window.setTimeout(() => {
       setIsSendToastVisible(false)
@@ -67,6 +76,7 @@ export const useRecoverAccountVerification = ({
       setErrorMessage('')
     }
 
+    setEmailToken(null)
     setCode('')
     resetTimer()
   }
@@ -80,18 +90,34 @@ export const useRecoverAccountVerification = ({
 
     if (isCodeVerified) {
       setIsCodeVerified(false)
+      setEmailToken(null)
     }
   }
 
-  const handleSendCode = () => {
-    if (!email.trim()) return
+  const handleSendCode = async () => {
+    if (!email.trim()) {
+      setErrorMessage('이메일을 입력해주세요.')
+      return
+    }
 
-    setIsCodeSent(true)
-    setIsCodeVerified(false)
-    setErrorMessage('')
-    setCode('')
-    startTimer()
-    setIsSendToastVisible(true)
+    try {
+      await handleSendEmailCode({ email })
+
+      setIsCodeSent(true)
+      setIsCodeVerified(false)
+      setErrorMessage('')
+      setCode('')
+      setEmailToken(null)
+      startTimer()
+      setIsSendToastVisible(true)
+    } catch (error) {
+      setIsCodeSent(false)
+      setIsCodeVerified(false)
+      setCode('')
+      setEmailToken(null)
+      setErrorMessage(getErrorMessage(error, '인증번호 전송에 실패했습니다.'))
+      resetTimer()
+    }
   }
 
   const validateCode = () => {
@@ -113,34 +139,56 @@ export const useRecoverAccountVerification = ({
     return true
   }
 
-  const handleVerifyCode = () => {
+  const handleVerifyCode = async () => {
     if (!validateCode()) {
       setIsCodeVerified(false)
       return
     }
 
-    // TODO: API 연동 시 아래 mock 로직 제거
-    if (code.trim() !== MOCK_VERIFY_CODE) {
-      setErrorMessage('인증코드가 일치하지 않습니다.')
-      setIsCodeVerified(false)
-      return
-    }
+    try {
+      const result = await handleVerifyEmailCode({
+        email,
+        code,
+      })
 
-    setErrorMessage('')
-    setIsCodeVerified(true)
-    stopTimer()
+      setEmailToken(result.email_token)
+      setErrorMessage('')
+      setIsCodeVerified(true)
+      stopTimer()
+    } catch (error) {
+      setEmailToken(null)
+      setIsCodeVerified(false)
+      setErrorMessage(getErrorMessage(error, '인증코드가 일치하지 않습니다.'))
+    }
   }
 
-  const handleCompleteButtonClick = () => {
-    if (!validateCode()) return
+  const handleCompleteButtonClick = async () => {
+    if (!validateCode()) {
+      return
+    }
 
     if (!isCodeVerified) {
       setErrorMessage('인증코드 확인을 완료해주세요.')
       return
     }
 
-    setErrorMessage('')
-    setIsCompletePopupVisible(true)
+    if (!emailToken) {
+      setErrorMessage('이메일 인증 토큰이 없습니다. 다시 인증해주세요.')
+      return
+    }
+
+    try {
+      await restoreAccountMutateAsync({
+        email_token: emailToken,
+      })
+
+      setErrorMessage('')
+      setIsCompletePopupVisible(true)
+    } catch (error) {
+      setErrorMessage(
+        getErrorMessage(error, '계정 복구에 실패했습니다. 다시 시도해주세요.')
+      )
+    }
   }
 
   const closeCompletePopup = () => {
@@ -156,6 +204,7 @@ export const useRecoverAccountVerification = ({
     isSendToastVisible,
     isCompletePopupVisible,
     formattedTime,
+    isPending,
     handleEmailChange,
     handleCodeChange,
     handleSendCode,

--- a/src/features/auth/shared/useEmailVerificationActions.ts
+++ b/src/features/auth/shared/useEmailVerificationActions.ts
@@ -1,0 +1,64 @@
+import {
+  useSendEmailVerificationCode,
+  useVerifyEmailVerificationCode,
+} from '@/api/signup'
+import { getErrorMessage } from '@/utils/getErrorMessage'
+import type {
+  SendEmailVerificationCodeRequest,
+  VerifyEmailVerificationCodeRequest,
+} from '@/types/auth-type/signup'
+
+type UseEmailVerificationActionsParams = {
+  onSendSuccess?: () => void
+  onSendError?: (message: string) => void
+  onVerifySuccess?: (emailToken: string) => void
+  onVerifyError?: (message: string) => void
+}
+
+export const useEmailVerificationActions = ({
+  onSendSuccess,
+  onSendError,
+  onVerifySuccess,
+  onVerifyError,
+}: UseEmailVerificationActionsParams = {}) => {
+  const sendEmailCodeMutation = useSendEmailVerificationCode()
+  const verifyEmailCodeMutation = useVerifyEmailVerificationCode()
+
+  const handleSendEmailCode = async ({
+    email,
+  }: SendEmailVerificationCodeRequest) => {
+    try {
+      await sendEmailCodeMutation.mutateAsync({ email: email.trim() })
+
+      onSendSuccess?.()
+    } catch (error) {
+      onSendError?.(getErrorMessage(error, '인증번호 전송에 실패했습니다.'))
+      throw error
+    }
+  }
+
+  const handleVerifyEmailCode = async ({
+    email,
+    code,
+  }: VerifyEmailVerificationCodeRequest) => {
+    try {
+      const result = await verifyEmailCodeMutation.mutateAsync({
+        email: email.trim(),
+        code: code.trim(),
+      })
+
+      onVerifySuccess?.(result.email_token)
+
+      return result
+    } catch (error) {
+      const message = getErrorMessage(error, '인증코드가 일치하지 않습니다.')
+      onVerifyError?.(message)
+      throw error
+    }
+  }
+
+  return {
+    handleSendEmailCode,
+    handleVerifyEmailCode,
+  }
+}

--- a/src/features/auth/signup/useSignup.ts
+++ b/src/features/auth/signup/useSignup.ts
@@ -5,16 +5,16 @@ import { useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { toast } from 'sonner'
 
-import { useCheckNickName } from '@/api/queries/useCheckNickName'
 import {
-  postSignup,
   useSendEmailVerificationCode,
-  useSendPhoneVerificationCode,
   useVerifyEmailVerificationCode,
+  postSignup,
+  useSendPhoneVerificationCode,
   useVerifyPhoneVerificationCode,
 } from '@/api/signup'
-import { useCodeVerification } from '@/features/auth/shared/useCodeVerification'
 import type { SignupRequest } from '@/types/auth-type/signup'
+import { useCheckNickName } from '@/api/queries/useCheckNickName'
+import { useCodeVerification } from '@/features/auth/shared/useCodeVerification'
 import type { CheckNicknameErrorResponse } from '@/types/checkNickName'
 import { getErrorMessage } from '@/utils/getErrorMessage'
 import {

--- a/src/hooks/usePhoneVerifySection.ts
+++ b/src/hooks/usePhoneVerifySection.ts
@@ -1,13 +1,13 @@
 import { useEffect, useRef, useState } from 'react'
 import { toast } from 'sonner'
 
+import { usePhoneVerification } from '@/hooks/usePhoneVerification'
+import { formatPhoneNumber } from '@/utils/formatPhoneNumber'
+import getPhoneButtonText, { type PhoneEditStep } from '@/utils/phoneButtonText'
 import {
   useSendPhoneVerificationCode,
   useVerifyPhoneVerificationCode,
 } from '@/api/signup'
-import { usePhoneVerification } from '@/hooks/usePhoneVerification'
-import { formatPhoneNumber } from '@/utils/formatPhoneNumber'
-import getPhoneButtonText, { type PhoneEditStep } from '@/utils/phoneButtonText'
 
 type VerificationStatus = 'default' | 'success' | 'danger'
 

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -22,8 +22,13 @@ import RecoverAccountModal from '@/features/auth/recover-account/RecoverAccountM
 import type { FindIdHandlers } from '@/hooks/useFindId'
 import type { FindPasswordHandlers } from '@/hooks/useFindPassword'
 import { useAuthStore } from '@/store/authStore'
-import type { loginSuccessResponse } from '@/types/auth-type/login'
 import { getErrorMessage } from '@/utils/getErrorMessage'
+import type {
+  loginErrorResponse,
+  loginSuccessResponse,
+} from '@/types/auth-type/login'
+import type { AxiosError } from 'axios'
+import { toast } from 'sonner'
 
 type SubmitLoginParams = {
   email: string
@@ -147,7 +152,7 @@ const LoginPage = () => {
           const result = await refetch()
 
           if (result.data) {
-            const user = result.data as any
+            const user = result.data
 
             setUser({
               id: user.id,
@@ -155,7 +160,24 @@ const LoginPage = () => {
             })
           }
 
-          navigate('/')
+          navigate(ROUTES_PATHS.HOME_PAGE)
+        },
+        onError: (error) => {
+          const axiosError = error as AxiosError<loginErrorResponse>
+          const status = axiosError.response?.status
+
+          if (status === 403) {
+            setOpenModal('recover')
+            return
+          }
+
+          const message =
+            axiosError.response?.data?.detail ??
+            axiosError.response?.data?.error_detail ??
+            axiosError.response?.data?.errorDetail?.detail ??
+            '로그인에 실패했습니다.'
+
+          toast.error(message)
         },
       }
     )

--- a/src/types/auth-type/login.ts
+++ b/src/types/auth-type/login.ts
@@ -14,4 +14,7 @@ export type loginErrorResponse = {
     detail?: string
     expireAt?: string //Todo: Date 객체인지 String인지 확인하기
   }
+  error_detail?: string
+  detail?: string
+  code?: string
 }

--- a/src/types/auth-type/restoreAccount.ts
+++ b/src/types/auth-type/restoreAccount.ts
@@ -1,0 +1,7 @@
+export type RestoreAccountRequest = {
+  email_token: string
+}
+
+export type RestoreAccountResponse = {
+  detail: string
+}

--- a/src/utils/getErrorMessage.ts
+++ b/src/utils/getErrorMessage.ts
@@ -19,6 +19,21 @@ export const getErrorMessage = (
       return responseData.error_detail
     }
 
+    if (Array.isArray(responseData.error_detail)) {
+      return responseData.error_detail[0] ?? fallbackMessage
+    }
+
+    if (
+      responseData.error_detail &&
+      typeof responseData.error_detail === 'object'
+    ) {
+      for (const value of Object.values(responseData.error_detail)) {
+        if (typeof value === 'string') return value
+        if (Array.isArray(value) && typeof value[0] === 'string')
+          return value[0]
+      }
+    }
+
     if (
       'error_detail' in responseData &&
       responseData.error_detail &&


### PR DESCRIPTION
## 📌 작업 내용

계정 복구 API 추가
- 계정 복구 endpoint, request/response 타입, mutation hook 추가
- 로그인 에러 응답 타입 확장
- 휴대폰 인증 관련 주석 문구 정리

계정 복구 플로우와 이메일 인증 로직 개선
- 계정 복구 모달에 이메일 인증 API 연동
- 공통 이메일 인증 액션 훅 추가
- 로그인 실패 시 탈퇴 계정은 복구 모달로 분기
- 에러 메시지 파싱 범위 확장

## 🔗 관련 이슈

- closes #133 

## ✅ 체크리스트

- [ ] 코드 컨벤션 확인
- [ ] lint 에러 없음
- [ ] 빌드 정상 확인
