### PR TITLE
fix: 닉네임 중복 확인 API 수정

### DIFF
--- a/src/api/checkNickName.ts
+++ b/src/api/checkNickName.ts
@@ -2,13 +2,13 @@ import type {
   CheckNicknameRequest,
   CheckNicknameSuccessResponse,
 } from '@/types/checkNickName'
-import { publicApi } from './api'
+import { api } from './api'
 import { APIS_PATHS } from '@/constants/apisPaths'
 
 export const postCheckNickname = async (
   payload: CheckNicknameRequest
 ): Promise<CheckNicknameSuccessResponse> => {
-  const { data } = await publicApi.post<CheckNicknameSuccessResponse>(
+  const { data } = await api.post<CheckNicknameSuccessResponse>(
     APIS_PATHS.CHECK_NICKNAME,
     payload
   )

--- a/src/mocks/handlers/checkNickNameHandlers.ts
+++ b/src/mocks/handlers/checkNickNameHandlers.ts
@@ -7,7 +7,7 @@ type CheckNicknameBody = {
 const duplicatedNicknames = ['관리자', 'admin', '오조오조']
 
 export const checkNickNameHandlers = [
-  http.post('*/api/v1/accounts/check-nickname', async ({ request }) => {
+  http.post('/api/v1/accounts/check-nickname', async ({ request }) => {
     const body = (await request.json()) as CheckNicknameBody
     const nickname = body.nickname?.trim()
 


### PR DESCRIPTION
## 📌 작업 내용

- 닉네임 중복확인 publicApi -> api로 변경
- 닉네임 중복확인 API 목 핸들러 경로 수정

## 🔗 관련 이슈

- closes #148 

## 📸 스크린샷 (선택)

## ✅ 체크리스트

- [x] 코드 컨벤션 확인
- [x] lint 에러 없음
- [x] 빌드 정상 확인
