### PR TITLE
fix: 헤더 경로 수정 및 예외처리 수정

### DIFF
--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -1,6 +1,6 @@
-import axios from 'axios'
 import { API_BASE_URL, APIS_PATHS } from '@/constants/apisPaths'
 import { useAuthStore } from '@/store/authStore'
+import axios from 'axios'
 
 export const publicApi = axios.create({
   baseURL: API_BASE_URL,

--- a/src/api/exam.ts
+++ b/src/api/exam.ts
@@ -12,6 +12,7 @@ export const getExamDeployments =
     const { data } = await api.get<ExamDeploymentListResponse>(
       EXAM_API_PATHS.DEPLOYMENTS
     )
+
     return data
   }
 

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -48,10 +48,12 @@ function Header() {
           <nav aria-label="주요 메뉴">
             <ul className="flex gap-15">
               <li className="py-4">
-                <Link to="/posts">커뮤니티</Link>
+                <a href="https://community.ozcodingschool.site/posts">
+                  커뮤니티
+                </a>
               </li>
               <li className="py-4">
-                <Link to="/qna">질의응답</Link>
+                <a href="https://qna.ozcodingschool.site/qna">질의응답</a>
               </li>
             </ul>
           </nav>

--- a/src/features/mypage/MyExamTab.tsx
+++ b/src/features/mypage/MyExamTab.tsx
@@ -1,4 +1,5 @@
 import { useExamDeployments } from '@/api/queries/exam/useExamDeployments'
+import Loading from '@/components/common/loading/Loading'
 import ExamEmptyState from '@/components/exam/ExamEmptyState'
 import ExamEntryCodeModal from '@/components/exam/ExamEntryCodeModal'
 import { EXAM_SUBJECT_ICON_MAP } from '@/constants/exam/examSubjectIconMap'
@@ -77,11 +78,14 @@ export default function MyExamTab() {
   const modalImageSrc = getExamImageSrc(selectedExam)
 
   if (isPending) {
-    return <div>로딩 중...</div>
+    return (
+      <div>
+        <Loading />
+      </div>
+    )
   }
-
   if (isError) {
-    return <div>시험 목록을 불러오지 못했습니다.</div>
+    return <ExamEmptyState title="응시 권한이 없습니다." />
   }
 
   return (

--- a/src/features/mypage/MyPageSideTab.tsx
+++ b/src/features/mypage/MyPageSideTab.tsx
@@ -11,7 +11,6 @@ const SIDE_TABS: { label: string; value: MyPageSideTabType }[] = [
   { label: '내 정보', value: 'info' },
   { label: '비밀번호 변경', value: 'password' },
 ]
-
 export default function MyPageSideTab({
   activeTab,
   onChangeTab,

--- a/src/features/mypage/UserMenu.tsx
+++ b/src/features/mypage/UserMenu.tsx
@@ -1,14 +1,14 @@
-import { useState } from 'react'
-import profileViewIcon from '../../assets/icons/profileViewIcon.svg'
+import { useGetMyInfo } from '@/api/queries/myInfo/useGetMyInfo'
+import { useLogout } from '@/api/queries/myInfo/useLogout'
 import Button from '@/components/ui/button'
-import { Link, useNavigate } from 'react-router-dom'
+import { INITIAL_REGISTER_VALUE } from '@/constants/initialRegisterValue'
 import { ROUTES_PATHS } from '@/constants/routesPaths'
 import type { SelectedCourseRegisterValue } from '@/types/api-response/course'
-import CourseRegisterModal from './student-register/CourseRegisterModal'
-import { useLogout } from '@/api/queries/myInfo/useLogout'
+import { useState } from 'react'
+import { Link, useNavigate } from 'react-router-dom'
 import { toast } from 'sonner'
-import { useGetMyInfo } from '@/api/queries/myInfo/useGetMyInfo'
-import { INITIAL_REGISTER_VALUE } from '@/constants/initialRegisterValue'
+import profileViewIcon from '../../assets/icons/profileViewIcon.svg'
+import CourseRegisterModal from './student-register/CourseRegisterModal'
 
 export default function UserMenu() {
   const [showUserMenu, setShowUserMenu] = useState(false)
@@ -38,16 +38,6 @@ export default function UserMenu() {
 
       setShowUserMenu(false)
       toast.success(result.detail ?? '로그아웃 되었습니다.')
-
-      /**
-       * TODO: 로그인 기능 완료 후 추가
-       *
-       * 1. 필요 시 인증 상태 제거
-       * 2. 필요 시 유저 관련 캐시 제거
-       * queryClient.removeQueries({ queryKey: MY_INFO_QUERY_KEY })
-       * 3. store 정리 필요
-       * store.removeToken
-       */
 
       navigate(ROUTES_PATHS.LOGIN_PAGE)
     } catch {

--- a/src/pages/MyPage.tsx
+++ b/src/pages/MyPage.tsx
@@ -10,7 +10,6 @@ import { useSearchParams } from 'react-router-dom'
 export default function MyPage() {
   const [searchParams] = useSearchParams()
   const tab = searchParams.get('tab')
-
   const initialTab: MyPageSideTabType =
     tab === 'exam' || tab === 'password' || tab === 'info' ? tab : 'info'
 


### PR DESCRIPTION
## 📌 작업 내용

-네비게이션 컴포넌트 수정: '커뮤니티' 및 '질의응답' 메뉴 클릭 시 SPA 내부 이동(Link)이 아닌 서브도메인 간 이동이 가능하도록 외부 링크 방식(a 태그)으로 변경

- 쪽지시험 응시 권한 예외 처리: 쪽지시험 접근 시 권한이 없는 사용자에 대한 예외 처리 로직 추가 (브랜치 fix/151-quiz-permission-exception 기준)

- 로그아웃 로직 안정화: 로그아웃 API 호출 실패 시에도 클라이언트 상태(Zustand, Query Cache)를 강제 초기화하여 보안 강화

## 🔗 관련 이슈

- closes #151 

## 📸 스크린샷 (선택)

## ✅ 체크리스트

- [ ] 코드 컨벤션 확인
- [ ] lint 에러 없음
- [ ] 빌드 정상 확인
