### PR TITLE
fix: 결과페이지 헤더 점수 오류 수정 

### DIFF
--- a/src/features/quiz-result/ResultHeader.tsx
+++ b/src/features/quiz-result/ResultHeader.tsx
@@ -5,6 +5,7 @@ type ResultHeaderProps = {
   questionCount: number
   cheatingCount: number
   elapsedTime: number
+  correctAnswerCount: number
   totalScore: number
   onBack: () => void
 }
@@ -15,13 +16,14 @@ function ResultHeader({
   cheatingCount,
   elapsedTime,
   totalScore,
+  correctAnswerCount,
   onBack,
 }: ResultHeaderProps) {
   const metaItems = [
     `총 문항 수: ${questionCount}`,
     `부정행위: ${cheatingCount}회`,
     `응시시간: ${elapsedTime}분`,
-    `응시 결과 점수: ${totalScore}점/100점`,
+    `응시 결과 점수: ${totalScore}점/${correctAnswerCount}점`,
   ]
 
   return (

--- a/src/pages/ResultPage.tsx
+++ b/src/pages/ResultPage.tsx
@@ -42,6 +42,7 @@ function ResultPage() {
         cheatingCount={resultData.cheating_count}
         elapsedTime={resultData.elapsed_time}
         totalScore={resultData.total_score}
+        correctAnswerCount={resultData.correct_answer_count}
         onBack={handleBack}
       />
       <section>


### PR DESCRIPTION
## 📌 작업 내용

- 점수 계산 로직 정정: 쪽지시험 결과 페이지에서 실제 정답 개수와 점수가 일치하지 않던 계산 오류 수정

## 🔗 관련 이슈

- closes #153

## 📸 스크린샷 (선택)

## ✅ 체크리스트

- [ ] 코드 컨벤션 확인
- [ ] lint 에러 없음
- [ ] 빌드 정상 확인
